### PR TITLE
Placement Bin Refactor

### DIFF
--- a/docs/specs/001_redesign/design.md
+++ b/docs/specs/001_redesign/design.md
@@ -1,9 +1,9 @@
 # **mm: A Unix‑Native Knowledge Operating System**
 
-*A whitepaper for the Item/Section model with logical navigation, Git‑friendly storage, and deterministic ordering.*
+_A whitepaper for the Item/Section model with logical navigation, Git‑friendly storage, and
+deterministic ordering._
 
-**Version:** 1.0 (design draft, updated)
-**Audience:** engineers, product designers, contributors
+**Version:** 1.0 (design draft, updated) **Audience:** engineers, product designers, contributors
 **Scope:** system design; no concrete implementation code beyond high‑level interface sketches
 
 ---
@@ -31,16 +31,22 @@
 
 ## Summary
 
-**mm** is a personal knowledge **Operating System** that exposes a logical, filesystem‑like navigation layer for a knowledge graph while keeping human‑editable content in plain text with Git‑friendly diffs.
+**mm** is a personal knowledge **Operating System** that exposes a logical, filesystem‑like
+navigation layer for a knowledge graph while keeping human‑editable content in plain text with
+Git‑friendly diffs.
 
 The system is built from **two primitives**:
 
-* **Item** — an addressable entity (note, task, event, concept). Items can have children.
-* **Section** — a numbered (or dated) *shelf* under a parent Item, written as a path like `:3-2` (numeric) or `:2025-09-22` (date).
+- **Item** — an addressable entity (note, task, event, concept). Items can have children.
+- **Section** — a numbered (or dated) _shelf_ under a parent Item, written as a path like `:3-2`
+  (numeric) or `:2025-09-22` (date).
 
-Each Item has **exactly one active placement**: *(parent Item, Section path, rank)*. Moving an Item updates **edges only**; physical files never move.
+Each Item has **exactly one active placement**: _(parent Item, Section path, rank)_. Moving an Item
+updates **edges only**; physical files never move.
 
-Navigation adopts Unix semantics (`cd`, `ls`, `pwd`, relative `.`/`..`/`-`) and a Git‑inspired relative notation for neighbors (`~N` = N steps back, `+N` = N steps forward). The workspace time zone is fixed.
+Navigation adopts Unix semantics (`cd`, `ls`, `pwd`, relative `.`/`..`/`-`) and a Git‑inspired
+relative notation for neighbors (`~N` = N steps back, `+N` = N steps forward). The workspace time
+zone is fixed.
 
 ---
 
@@ -48,17 +54,18 @@ Navigation adopts Unix semantics (`cd`, `ls`, `pwd`, relative `.`/`..`/`-`) and 
 
 ### Goals
 
-* **Simple diffs, conflict‑resistant Git workflow.**
-* **One mental model**: Items placed under Items, split by **Sections**; one active placement per Item.
-* **Fast navigation** by dates, aliases, or IDs; *logical CWD* to reduce typing.
-* **Deterministic ordering** via **LexoRank** (stable inserts).
-* **Fixed workspace TZ** for all date math.
+- **Simple diffs, conflict‑resistant Git workflow.**
+- **One mental model**: Items placed under Items, split by **Sections**; one active placement per
+  Item.
+- **Fast navigation** by dates, aliases, or IDs; _logical CWD_ to reduce typing.
+- **Deterministic ordering** via **LexoRank** (stable inserts).
+- **Fixed workspace TZ** for all date math.
 
 ### Non‑Goals
 
-* **Multi‑placement** (no simultaneous presence in multiple parents).
-* Filesystem symlink semantics.
-* Time‑zone migrations (changing TZ would require a full re‑partition).
+- **Multi‑placement** (no simultaneous presence in multiple parents).
+- Filesystem symlink semantics.
+- Time‑zone migrations (changing TZ would require a full re‑partition).
 
 ---
 
@@ -66,31 +73,32 @@ Navigation adopts Unix semantics (`cd`, `ls`, `pwd`, relative `.`/`..`/`-`) and 
 
 ### Item
 
-* Identity: **UUID v7** (timestamp‑embedded).
-* Content: `content.md` (human‑editable, title in Markdown H1).
-* Metadata: `meta.json` (status, timestamps, alias, etc.; *no title*).
-* Exactly **one active placement** in the logical graph.
+- Identity: **UUID v7** (timestamp‑embedded).
+- Content: `content.md` (human‑editable, title in Markdown H1).
+- Metadata: `meta.json` (status, timestamps, alias, etc.; _no title_).
+- Exactly **one active placement** in the logical graph.
 
 ### Section
 
-* A **path** of segments under a parent Item:
+- A **path** of segments under a parent Item:
 
-  * **Numeric**: `:1`, `:1-2`, `:3-2-1`, …
-  * **Date** *(root only)*: `:YYYY-MM-DD`.
-* Sections partition a parent’s children (e.g., a book’s chapter/page).
+  - **Numeric**: `:1`, `:1-2`, `:3-2-1`, …
+  - **Date** _(root only)_: `:YYYY-MM-DD`.
+- Sections partition a parent’s children (e.g., a book’s chapter/page).
 
 ### Root & Date Sections
 
-* `root:` is the global origin.
-* **Date Sections are valid only under `root:`.**
-* Input like `2025-04-01/...` is sugar for `root:2025-04-01/...` (internally normalized to `root:`).
+- `root:` is the global origin.
+- **Date Sections are valid only under `root:`.**
+- Input like `2025-04-01/...` is sugar for `root:2025-04-01/...` (internally normalized to `root:`).
 
 ### Invariants
 
-* **Single parent** (active placement): an Item cannot be in two places at once.
-* **No cycles**: an Item cannot be a descendant of itself.
-* **No duplicate edges** (same parent + same section + same child).
-* **Physical immobility**: files reside under their **creation date** forever; moves update only edges.
+- **Single parent** (active placement): an Item cannot be in two places at once.
+- **No cycles**: an Item cannot be a descendant of itself.
+- **No duplicate edges** (same parent + same section + same child).
+- **Physical immobility**: files reside under their **creation date** forever; moves update only
+  edges.
 
 ---
 
@@ -98,21 +106,23 @@ Navigation adopts Unix semantics (`cd`, `ls`, `pwd`, relative `.`/`..`/`-`) and 
 
 ### Tokens
 
-* **Dates / relative dates**: `2025-09-22`, `today`, `td`, `next-monday`, `+mon`, `last-friday`, `~fri`, `+2w`, `~1m`, `+7d`, `~10d`, `+1y`, `~2y`, etc.
-  *Relative weekdays and periods are valid only under `root:` (date Sections).*
-* **IDs**: full **UUID v7** (short IDs are not used).
-* **Aliases**: *Unicode slug* (letters/numbers/marks from any script, plus `_` `-` `.`; no whitespace or control chars). Length: **1–64 code points**.
-  Uniqueness is evaluated on a **canonical key** (see below).
-  **Reserved shapes** (not allowed as aliases):
+- **Dates / relative dates**: `2025-09-22`, `today`, `td`, `next-monday`, `+mon`, `last-friday`,
+  `~fri`, `+2w`, `~1m`, `+7d`, `~10d`, `+1y`, `~2y`, etc. _Relative weekdays and periods are valid
+  only under `root:` (date Sections)._
+- **IDs**: full **UUID v7** (short IDs are not used).
+- **Aliases**: _Unicode slug_ (letters/numbers/marks from any script, plus `_` `-` `.`; no
+  whitespace or control chars). Length: **1–64 code points**. Uniqueness is evaluated on a
+  **canonical key** (see below). **Reserved shapes** (not allowed as aliases):
 
-  * Absolute dates: `YYYY‑MM‑DD`
-  * Numeric‑section shapes: `^\d+(?:-\d+)+$` (e.g., `1-2`, `12-3-4`)
-  * Relative step: `^[~+]\d+$`
-  * Relative weekday: `^[~+](mon|tue|wed|thu|fri|sat|sun)$`
-  * Relative period: `^[~+]\d+[dwmy]$`
-* **Aliases (auto‑generated fallback)**: unchanged CVCV‑base36 (ASCII) pattern from Appendix C. Users may later override with a Unicode alias; uniqueness still checked on the canonical key.
-* **Section path** (numeric): `:<n>` or `:<n>-<m>-…` (numbers only).
-  *Date Sections (`:YYYY-MM-DD`) are valid only under `root:`.*
+  - Absolute dates: `YYYY‑MM‑DD`
+  - Numeric‑section shapes: `^\d+(?:-\d+)+$` (e.g., `1-2`, `12-3-4`)
+  - Relative step: `^[~+]\d+$`
+  - Relative weekday: `^[~+](mon|tue|wed|thu|fri|sat|sun)$`
+  - Relative period: `^[~+]\d+[dwmy]$`
+- **Aliases (auto‑generated fallback)**: unchanged CVCV‑base36 (ASCII) pattern from Appendix C.
+  Users may later override with a Unicode alias; uniqueness still checked on the canonical key.
+- **Section path** (numeric): `:<n>` or `:<n>-<m>-…` (numbers only). _Date Sections (`:YYYY-MM-DD`)
+  are valid only under `root:`._
 
 ### Resolution Priority
 
@@ -130,14 +140,17 @@ root:today/book-professional-product-owner:1-2/pako-9rw
 2025-04-01/bugi-j1a:1-2/pako-9rw         # 'root:' omitted (sugar)
 ```
 
-If a UUID/alias is ambiguous (alias must be unique; UUID must be full), mm returns a **clear error** with candidates.
+If a UUID/alias is ambiguous (alias must be unique; UUID must be full), mm returns a **clear error**
+with candidates.
 
 **Alias/Tag canonicalization**
 
-* **Canonicalization**: when storing/searching aliases and tags, mm computes a **canonical key** as **NFKC normalization + casefold** (future room for UTS#39 confusable skeleton if needed).
-* **Two‑field model**: store both **raw** (as entered/displayed) and **canonical\_key** (for matching/uniqueness).
-* All lookups and indexes use **canonical\_key**; all UI displays use **raw**.
-* User‑provided aliases may include non‑ASCII: e.g., `要約`, `設計メモ`, `메모-1`.
+- **Canonicalization**: when storing/searching aliases and tags, mm computes a **canonical key** as
+  **NFKC normalization + casefold** (future room for UTS#39 confusable skeleton if needed).
+- **Two‑field model**: store both **raw** (as entered/displayed) and **canonical\_key** (for
+  matching/uniqueness).
+- All lookups and indexes use **canonical\_key**; all UI displays use **raw**.
+- User‑provided aliases may include non‑ASCII: e.g., `要約`, `設計メモ`, `메모-1`.
 
 ### **Parent‑anchored range locators**
 
@@ -147,27 +160,21 @@ A range **must** be expressed as a **single parent anchor** followed by a **Sect
 <parent : section_start .. section_end>
 ```
 
-* The **right‑hand side MUST NOT repeat the parent**.
-  ❌ `root:2025-09-01..root:2025-09-07` (invalid)
-  ✅ `root:2025-09-01..2025-09-07`
-  ✅ `root:~mon..+fri`
-  ✅ `book-ppo:1-2..1-5`
+- The **right‑hand side MUST NOT repeat the parent**. ❌ `root:2025-09-01..root:2025-09-07`
+  (invalid) ✅ `root:2025-09-01..2025-09-07` ✅ `root:~mon..+fri` ✅ `book-ppo:1-2..1-5`
 
-* **Numeric Section ranges**: both ends must have the **same depth and lineage** (same prefix), and the final segment must be **non‑decreasing**.
-  ✅ `book-ppo:1-2..1-5`
-  ❌ `book-ppo:1-2..1-1` (reverse order)
-  ❌ `book-ppo:1-2..2-1` (crossing branches / different lineage)
+- **Numeric Section ranges**: both ends must have the **same depth and lineage** (same prefix), and
+  the final segment must be **non‑decreasing**. ✅ `book-ppo:1-2..1-5` ❌ `book-ppo:1-2..1-1`
+  (reverse order) ❌ `book-ppo:1-2..2-1` (crossing branches / different lineage)
 
-* **Date Section ranges (under `root:`)**: both ends must resolve to dates; mixing absolute and relative forms is allowed.
-  ✅ `root:2025-09-01..2025-09-07`
-  ✅ `root:2025-09-01..+2w`
-  ✅ `root:~mon..+fri`
+- **Date Section ranges (under `root:`)**: both ends must resolve to dates; mixing absolute and
+  relative forms is allowed. ✅ `root:2025-09-01..2025-09-07` ✅ `root:2025-09-01..+2w` ✅
+  `root:~mon..+fri`
 
 > Sugar: when the left side is an absolute date without `root:`, mm treats it as `root:<date>`.
 > Example: `2025-09-01..+2w` ⇒ `root:2025-09-01..+2w`.
 
 Invalid forms yield clear errors (e.g., repeated parent, reversed numeric range, lineage mismatch).
-
 
 ---
 
@@ -177,20 +184,20 @@ mm maintains a **logical CWD** (current working directory) in the graph.
 
 ### Commands
 
-* `cd <locator>` — move CWD to an Item (optionally with Section).
-* `pwd` — print the normalized locator.
-* `ls [<locator>|<range>]` — list current location or a target location without changing CWD.
+- `cd <locator>` — move CWD to an Item (optionally with Section).
+- `pwd` — print the normalized locator.
+- `ls [<locator>|<range>]` — list current location or a target location without changing CWD.
 
 ### Relative tokens
 
-* `.` — current location
-* `..` — logical parent (from `:3-2` to `:3`; from an Item to its parent)
-* `-` — previous location
+- `.` — current location
+- `..` — logical parent (from `:3-2` to `:3`; from an Item to its parent)
+- `-` — previous location
 
 ### Git‑like relative steps (Section‑relative, not index‑relative)
 
-* `~N` — N steps **back** in the **last Section segment**
-* `+N` — N steps **forward** in the **last Section segment**
+- `~N` — N steps **back** in the **last Section segment**
+- `+N` — N steps **forward** in the **last Section segment**
 
 Examples:
 
@@ -224,14 +231,15 @@ mm ls book-ppo:1-2..1-1                  # ❌ reversed order
 mm ls book-ppo:1-2..2-1                  # ❌ crossing hierarchy
 ```
 
-`~N` / `+N` remain **Section‑relative** (last segment only).
-Relative weekdays (`+mon`, `~fri`) and periods (`+2w`, `~1m`, `+7d`, `~1y`) are **date‑relative** and valid only under `root:`.
+`~N` / `+N` remain **Section‑relative** (last segment only). Relative weekdays (`+mon`, `~fri`) and
+periods (`+2w`, `~1m`, `+7d`, `~1y`) are **date‑relative** and valid only under `root:`.
 
 ### State
 
-* Session env var `MM_CWD`. A helper subcommand can print `export MM_CWD=...` for shell eval.
-* Workspace default stored in `~/.mm/<workspace>/.state.json`.
-* When CWD becomes invalid (deleted/renamed), mm falls back to the nearest valid ancestor, then to `root:`.
+- Session env var `MM_CWD`. A helper subcommand can print `export MM_CWD=...` for shell eval.
+- Workspace default stored in `~/.mm/<workspace>/.state.json`.
+- When CWD becomes invalid (deleted/renamed), mm falls back to the nearest valid ancestor, then to
+  `root:`.
 
 ---
 
@@ -278,25 +286,29 @@ Relative weekdays (`+mon`, `~fri`) and periods (`+2w`, `~1m`, `+7d`, `~1y`) are 
 
 **Notes**
 
-* **Authoritative ordering** lives in the **parent’s** `edges/` (for root date Sections, under `items/YYYY/MM/DD/edges/YYYY-MM-DD/` as shown above).
-* Child Items may cache their current placement (parent id + Section) in `meta.json` for reverse lookup (rank remains authoritative on the parent side).
-* The **title** is not in `meta.json`. It is the first non‑empty Markdown H1 in `content.md`.
-  If no H1 is found, the Item is treated as **Untitled**. For performance, title lookup streams the file until the first non‑blank line.
-* Using a **hash of the canonical key** in filenames avoids filesystem normalization issues across OSes and prevents collisions with special characters.
+- **Authoritative ordering** lives in the **parent’s** `edges/` (for root date Sections, under
+  `items/YYYY/MM/DD/edges/YYYY-MM-DD/` as shown above).
+- Child Items may cache their current placement (parent id + Section) in `meta.json` for reverse
+  lookup (rank remains authoritative on the parent side).
+- The **title** is not in `meta.json`. It is the first non‑empty Markdown H1 in `content.md`. If no
+  H1 is found, the Item is treated as **Untitled**. For performance, title lookup streams the file
+  until the first non‑blank line.
+- Using a **hash of the canonical key** in filenames avoids filesystem normalization issues across
+  OSes and prevents collisions with special characters.
 
 ---
 
 ## Deterministic Ordering (LexoRank)
 
-* Siblings in the same `(parent, section)` are ordered by **LexoRank** (string).
-* Insert modes:
+- Siblings in the same `(parent, section)` are ordered by **LexoRank** (string).
+- Insert modes:
 
-  * `head`, `tail`
-  * `before:<sibling-id>`, `after:<sibling-id>`
-* Rebalancing:
+  - `head`, `tail`
+  - `before:<sibling-id>`, `after:<sibling-id>`
+- Rebalancing:
 
-  * `mm doctor --reindex` (when density becomes high).
-* Stable display tiebreak: `created_at` ascending.
+  - `mm doctor --reindex` (when density becomes high).
+- Stable display tiebreak: `created_at` ascending.
 
 ---
 
@@ -304,17 +316,17 @@ Relative weekdays (`+mon`, `~fri`) and periods (`+2w`, `~1m`, `+7d`, `~1y`) are 
 
 ### Create
 
-* Default creates at **CWD tail**:
+- Default creates at **CWD tail**:
 
   ```
   mm n "some note"
   ```
-* Explicit parent & Section:
+- Explicit parent & Section:
 
   ```
   mm n "quote" --parent book-ppo:3
   ```
-* Physical path is always `items/<creation-date>/<uuid>/…`.
+- Physical path is always `items/<creation-date>/<uuid>/…`.
 
 ### Move (placement)
 
@@ -324,47 +336,53 @@ mm mv <id> <placement>
 
 **Placement forms**
 
-* **Explicit location (parent + Section):**
+- **Placement bin** — notation `<parent[:section]>` describing a parent Item (or `root`) and the
+  Section bucket that placement edges share. Bins are reusable anywhere a placement target is
+  needed.
+- **Explicit location (parent + Section):**
 
-  * `head:<parent[:section]>`
-  * `tail:<parent[:section]>`
-  * `<parent[:section]>` (same as `tail:<parent[:section]>`)
-* **Relative to a sibling (adopts sibling’s parent + Section):**
+  - `head:<parent[:section]>`
+  - `tail:<parent[:section]>`
+  - `<parent[:section]>` (same as `tail:<parent[:section]>`)
+- **Relative to a sibling (adopts sibling’s parent + Section):**
 
-  * `after:<id2>`
-  * `before:<id2>`
+  - `after:<id2>`
+  - `before:<id2>`
 
 > Physical files do not move.
 
 ### List
 
-* `mm ls` lists CWD by **rank asc**, then **created\_at asc**.
-* `mm ls <locator | range>` lists a target without changing CWD.
-* **Calendar day lists exclude** Items that have been moved away (the day is birthplace, not current placement).
+- `mm ls` lists CWD by **rank asc**, then **created\_at asc**.
+- `mm ls <locator | range>` lists a target without changing CWD.
+- **Calendar day lists exclude** Items that have been moved away (the day is birthplace, not current
+  placement).
 
 ### Inspect
 
-* `mm where <id>` prints **Logical** (parent + Section + rank) and **Physical** (filesystem path).
+- `mm where <id>` prints **Logical** (parent + Section + rank) and **Physical** (filesystem path).
 
 ---
 
 ## Time & Ranges
 
-* The workspace time zone is fixed (e.g., `"Asia/Tokyo"`).
-* **Relative weekdays**: `+mon|tue|…|sun`, `~mon|…|sun` (next/previous weekday).
-  *Valid only under `root:`.*
-* **Relative periods**: `±Nd`, `±Nw`, `±Nm`, `±Ny` (days, weeks, months, years).
-  *Valid only under `root:`.*
-* **Parent‑anchored ranges**:
+- The workspace time zone is fixed (e.g., `"Asia/Tokyo"`).
+- **Relative weekdays**: `+mon|tue|…|sun`, `~mon|…|sun` (next/previous weekday). _Valid only under
+  `root:`._
+- **Relative periods**: `±Nd`, `±Nw`, `±Nm`, `±Ny` (days, weeks, months, years). _Valid only under
+  `root:`._
+- **Parent‑anchored ranges**:
 
-  * **Dates** (under `root:`): `root:<dateA>..<dateB>` | `root:<dateA>..+<period>` | `root:~<weekday>..+<period>` | `root:~<weekday>..+<weekday>` …
-  * **Numeric Sections** (under any Item): `<alias|id> : <a-b-…-x> .. <a-b-…-y>`, with **same prefix** and **x ≤ y**.
+  - **Dates** (under `root:`): `root:<dateA>..<dateB>` | `root:<dateA>..+<period>` |
+    `root:~<weekday>..+<period>` | `root:~<weekday>..+<weekday>` …
+  - **Numeric Sections** (under any Item): `<alias|id> : <a-b-…-x> .. <a-b-…-y>`, with **same
+    prefix** and **x ≤ y**.
 
 Prohibited:
 
-* Repeating the parent on the right side: `X:S..X:T` (**invalid**).
-* Reversed numeric ranges (`…x..y` with `x > y`).
-* Crossing hierarchy (`1-2..2-1`, differing prefixes/depths).
+- Repeating the parent on the right side: `X:S..X:T` (**invalid**).
+- Reversed numeric ranges (`…x..y` with `x > y`).
+- Crossing hierarchy (`1-2..2-1`, differing prefixes/depths).
 
 ---
 
@@ -372,16 +390,16 @@ Prohibited:
 
 Pre‑save / maintenance checks:
 
-* Every `*.edge.json` points to an existing **Item** (no edge→edge).
-* No duplicates within the same `(parent, section)`.
-* No cycles in the parent/child graph.
-* JSON schema version matches; UTF‑8 (NFC), LF newlines.
-* Aliases are unique (index enforces uniqueness).
+- Every `*.edge.json` points to an existing **Item** (no edge→edge).
+- No duplicates within the same `(parent, section)`.
+- No cycles in the parent/child graph.
+- JSON schema version matches; UTF‑8 (NFC), LF newlines.
+- Aliases are unique (index enforces uniqueness).
 
 Maintenance:
 
-* `mm doctor --reindex` (rank compaction).
-* `mm doctor --fix` (conservative safe fixes).
+- `mm doctor --reindex` (rank compaction).
+- `mm doctor --fix` (conservative safe fixes).
 
 ---
 
@@ -391,14 +409,14 @@ A thin **MCP** surface mirrors CLI semantics 1:1.
 
 **Capabilities (illustrative)**
 
-* `resolve(token) → Locator`
-* `cwd.get() → Locator` / `cwd.set(Locator)`
-* `items.get(id) → Item`
-* `items.list(parent: Locator) → [Child]`
-* `items.create(title, parent?: Locator, insertion?: {mode, refId?}) → {item, placement}`
-* `items.move(id, placement: { head|tail:<locator> | after|before:<id2> })`
-* `items.close(id)` / `items.reopen(id)`
-* `inspect.where(id) → { logical: Placement, physical: FsPath }`
+- `resolve(token) → Locator`
+- `cwd.get() → Locator` / `cwd.set(Locator)`
+- `items.get(id) → Item`
+- `items.list(parent: Locator) → [Child]`
+- `items.create(title, parent?: Locator, insertion?: {mode, refId?}) → {item, placement}`
+- `items.move(id, placement: { head|tail:<locator> | after|before:<id2> })`
+- `items.close(id)` / `items.reopen(id)`
+- `inspect.where(id) → { logical: Placement, physical: FsPath }`
 
 > Wire formats and authentication are out of scope here.
 
@@ -406,19 +424,21 @@ A thin **MCP** surface mirrors CLI semantics 1:1.
 
 ## Concurrency, Git, and Conflict Strategy
 
-* Writes are **atomic** (temp file + rename).
-* The system is **append‑oriented** on edges; merges are typically line‑local.
-* Rank collisions surface as small JSON diffs and are resolved by reindexing.
-* Competing moves on the same Item -> last‑writer wins at edge level (content is unaffected).
+- Writes are **atomic** (temp file + rename).
+- The system is **append‑oriented** on edges; merges are typically line‑local.
+- Rank collisions surface as small JSON diffs and are resolved by reindexing.
+- Competing moves on the same Item -> last‑writer wins at edge level (content is unaffected).
 
 ---
 
 ## Security & Integrity
 
-* Everything is plain text; no hidden binaries in core storage.
-* Optional hardening (e.g., signed commits) can be layered externally.
-* Sensitive data policy remains the workspace owner’s responsibility.
-* Indexing with **hashed canonical keys** avoids platform‑dependent Unicode normalization pitfalls in filenames and reduces spoofing via look‑alike characters (further hardening possible by adding UTS#39 confusable checks later).
+- Everything is plain text; no hidden binaries in core storage.
+- Optional hardening (e.g., signed commits) can be layered externally.
+- Sensitive data policy remains the workspace owner’s responsibility.
+- Indexing with **hashed canonical keys** avoids platform‑dependent Unicode normalization pitfalls
+  in filenames and reduces spoofing via look‑alike characters (further hardening possible by adding
+  UTS#39 confusable checks later).
 
 ---
 
@@ -516,49 +536,55 @@ dd                = digit , digit ;
 
 1. **Numeric ranges**
 
-   * In `range` with numeric Sections, both ends must share the **same prefix** and **same depth**.
-   * The final numeric segment must be **non-decreasing** (`x ≤ y`).
-   * Example: `book-ppo:1-2..1-5` is valid.
-   * Example: `book-ppo:1-2..1-1` (reverse) and `book-ppo:1-2..2-1` (cross-hierarchy) are invalid.
+   - In `range` with numeric Sections, both ends must share the **same prefix** and **same depth**.
+   - The final numeric segment must be **non-decreasing** (`x ≤ y`).
+   - Example: `book-ppo:1-2..1-5` is valid.
+   - Example: `book-ppo:1-2..1-1` (reverse) and `book-ppo:1-2..2-1` (cross-hierarchy) are invalid.
 
 2. **Date ranges**
 
-   * In `range` with date Sections (parent = `root`), both ends must resolve to valid dates.
-   * Absolute (`YYYY-MM-DD`) and relative (`+2w`, `~mon`) forms may be mixed.
-   * Example: `root:2025-09-01..+2w` is valid.
+   - In `range` with date Sections (parent = `root`), both ends must resolve to valid dates.
+   - Absolute (`YYYY-MM-DD`) and relative (`+2w`, `~mon`) forms may be mixed.
+   - Example: `root:2025-09-01..+2w` is valid.
 
 3. **No repeated parent**
 
-   * In `range`, the right side must **not repeat the parent**.
-   * Example: `X:S..X:T` is invalid.
-   * Example: `root:2025-09-01..root:2025-09-07` is invalid; use `root:2025-09-01..2025-09-07` without repeating `root:` on the right.
+   - In `range`, the right side must **not repeat the parent**.
+   - Example: `X:S..X:T` is invalid.
+   - Example: `root:2025-09-01..root:2025-09-07` is invalid; use `root:2025-09-01..2025-09-07`
+     without repeating `root:` on the right.
 
 4. **Date sections are root-only**
 
-   * `date-section` (absolute, relative day, relative period, relative weekday) is valid **only when parent = root**.
-   * Example: `root:today` is valid, `book-ppo:today` is invalid.
+   - `date-section` (absolute, relative day, relative period, relative weekday) is valid **only when
+     parent = root**.
+   - Example: `root:today` is valid, `book-ppo:today` is invalid.
 
 5. **Relative steps under CWD**
 
-   * If a `locator` or `range` begins with a bare `section` (no parent), the current working directory (CWD) provides the parent.
-   * If the token matches `date-section`, normalize to `root:<date-section>`.
-   * Otherwise treat it as `<cwd>:<section>`.
-   * If CWD is not defined or is not a Section context, relative steps like `~N` / `+N` are invalid.
+   - If a `locator` or `range` begins with a bare `section` (no parent), the current working
+     directory (CWD) provides the parent.
+   - If the token matches `date-section`, normalize to `root:<date-section>`.
+   - Otherwise treat it as `<cwd>:<section>`.
+   - If CWD is not defined or is not a Section context, relative steps like `~N` / `+N` are invalid.
 
 6. **Alias disambiguation**
 
-   * Aliases must not lexically collide with reserved forms: absolute dates (`YYYY-MM-DD`), numeric sections (`1-2-3`), or relative tokens (`~N`, `+N`, `~mon`, `+2w`, etc.).
+   - Aliases must not lexically collide with reserved forms: absolute dates (`YYYY-MM-DD`), numeric
+     sections (`1-2-3`), or relative tokens (`~N`, `+N`, `~mon`, `+2w`, etc.).
 
 7. **Alias/Tag canonicalization**
 
-  * `canonical_key := NFKC(raw) → casefold(raw)`; all uniqueness/searching uses `canonical_key`.
-  * **Reserved shapes** (as listed above) must be rejected for aliases/tags.
-  * **Filenames** for `.index/aliases/*` and `tags/*` MUST use `hash(canonical_key)` (not the raw string).
-  * **Display vs. key**: mm always displays `raw`, never `canonical_key`.
+- `canonical_key := NFKC(raw) → casefold(raw)`; all uniqueness/searching uses `canonical_key`.
+- **Reserved shapes** (as listed above) must be rejected for aliases/tags.
+- **Filenames** for `.index/aliases/*` and `tags/*` MUST use `hash(canonical_key)` (not the raw
+  string).
+- **Display vs. key**: mm always displays `raw`, never `canonical_key`.
 
 ## Appendix C — Alias Autogeneration
 
-When an Item is created without an explicit alias, mm generates a **pronounceable slug** of the form:
+When an Item is created without an explicit alias, mm generates a **pronounceable slug** of the
+form:
 
 ```
 auto_alias := C V C V "-" base36^3
@@ -566,12 +592,15 @@ C := one consonant in [b c d f g h j k l m n p q r s t v w x y z]
 V := one vowel in [a e i o u]
 base36 := [0-9a-z]
 ```
+
 **Examples:** `bugi-j1a`, `pako-9rw`
 
-* Auto aliases are lowercase ASCII.
-* Auto aliases are **fallbacks** only. A user may set a Unicode alias later; **uniqueness is evaluated against `canonical_key`**.
-* Uniqueness is enforced via an alias index (`.index/aliases/…`).
-* Once assigned, an alias is persisted with the Item (renaming is allowed by explicit user action only).
+- Auto aliases are lowercase ASCII.
+- Auto aliases are **fallbacks** only. A user may set a Unicode alias later; **uniqueness is
+  evaluated against `canonical_key`**.
+- Uniqueness is enforced via an alias index (`.index/aliases/…`).
+- Once assigned, an alias is persisted with the Item (renaming is allowed by explicit user action
+  only).
 
 ---
 

--- a/docs/specs/001_redesign/plan.md
+++ b/docs/specs/001_redesign/plan.md
@@ -2,26 +2,14 @@
 
 ## Current State Snapshot
 
-- The domain item model still stores a `ContainerPath` string for placement
-  (`src/domain/models/item.ts:59`) and delegates ordering to legacy container edges, so there is no
-  notion of parent Item + Section pairing yet.
-- Container infrastructure is calendar-oriented (`src/domain/models/container.ts:214-244`) and the
-  filesystem adapters persist `nodes/<year>/<month>/<day>/<id>` plus container edge directories
-  (`src/infrastructure/fileSystem/item_repository.ts:41-55`,
-  `src/infrastructure/fileSystem/container_repository.ts:19-28`), which diverges from the redesign
-  layout under `items/` with per-section edge folders.
-- Identifier resolution still depends on 7-character short IDs
-  (`src/domain/services/item_resolution_service.ts:35-71`) and the repository exposes
-  `findByShortId` (`src/domain/repositories/item_repository.ts:11-18`), conflicting with the
-  redesign’s “UUID v7 only” rule.
-- Alias and context primitives enforce lowercase ASCII slugs
-  (`src/domain/primitives/alias_slug.ts:28-84`, `src/domain/primitives/tag_slug.ts:21-61`) and
-  repositories persist files named by the raw slug
-  (`src/infrastructure/fileSystem/alias_repository.ts:18-70`), whereas the redesign requires Unicode
-  input, canonical keys, and hashed filenames.
-- CLI flows (e.g. note creation) still assume day containers and short IDs
-  (`src/presentation/cli/commands/note.ts:67-93`), with no support for Sections, ranges, or logical
-  CWD semantics.
+- The domain model now represents placement as `{ bin, rank }`; create-item/status workflows use the
+  new API, but section trees are not wired and move/list services still expect container-era data.
+- File-system adapters continue to write to `nodes/` with container edges; the redesign layout under
+  `items/` and placement bins has not been adopted yet.
+- Identifier resolution still offers short-ID lookups via `ItemResolutionService`; the planned v7-only
+  locator stack is not in place.
+- Alias/tag primitives remain ASCII-focused; canonical key + hashing work is pending.
+- CLI flows (note/close/etc.) still assume day containers and short IDs, with no bin-aware navigation.
 
 ## Guiding Constraints
 

--- a/src/domain/models/item.ts
+++ b/src/domain/models/item.ts
@@ -148,14 +148,16 @@ const instantiate = (data: ItemData, edges: ReadonlyArray<Edge>): Item => {
     placement: Placement,
     occurredAt: DateTime,
   ): Item {
-    const sameKind = this.data.placement.kind === placement.kind;
+    const currentKind = this.data.placement.kind();
+    const nextKind = placement.kind();
+    const sameKind = currentKind === nextKind;
     const sameParent = sameKind && (
-      placement.kind === "root"
-        ? this.data.placement.kind === "root"
-        : this.data.placement.kind === "item" &&
-          this.data.placement.parentId.toString() === placement.parentId.toString()
+      nextKind === "root" ? currentKind === "root" : currentKind === "item" &&
+        this.data.placement.parentId()?.toString() ===
+          placement.parentId()?.toString()
     );
-    const sameSection = this.data.placement.section.toString() === placement.section.toString();
+    const sameSection = this.data.placement.section()?.toString() ===
+      placement.section()?.toString();
     const sameRank = this.data.placement.rank.compare(placement.rank) === 0;
 
     if (sameKind && sameParent && sameSection && sameRank) {

--- a/src/domain/models/item_test.ts
+++ b/src/domain/models/item_test.ts
@@ -83,7 +83,7 @@ Deno.test("parseItem parses full snapshot payload", () => {
   assertEquals(item.data.icon.toString(), "task");
   assertEquals(item.data.status.toString(), "closed");
   assertEquals(item.data.placement.rank.toString(), "b1");
-  assertEquals(item.data.placement.section.toString(), ":2024-09-21");
+  assertEquals(item.data.placement.section()?.toString(), ":2024-09-21");
   assertEquals(item.data.alias?.toString(), "focus-work");
   assertEquals(item.data.context?.toString(), "deep-work");
   assertEquals(item.data.body, "Example body");
@@ -168,7 +168,7 @@ Deno.test("Item.relocate updates placement", () => {
 
   const relocated = base.relocate(placement, relocateAt);
   assertEquals(relocated.data.placement.rank.toString(), "b1");
-  assertEquals(relocated.data.placement.section.toString(), ":1");
+  assertEquals(relocated.data.placement.section()?.toString(), ":1");
   assert(relocated.data.updatedAt.equals(relocateAt), "updatedAt should match relocate timestamp");
 });
 

--- a/src/domain/models/placement_test.ts
+++ b/src/domain/models/placement_test.ts
@@ -42,12 +42,12 @@ Deno.test("parsePlacement parses snapshot payload", () => {
   const result = parsePlacement(snapshot);
   const placement = unwrapOk(result, "parse placement");
 
-  if (placement.kind !== "item") {
+  if (placement.kind() !== "item") {
     throw new Error("expected item placement");
   }
 
-  assertEquals(placement.parentId.toString(), snapshot.parentId);
-  assertEquals(placement.section.toString(), snapshot.section);
+  assertEquals(placement.parentId()?.toString(), snapshot.parentId);
+  assertEquals(placement.section()?.toString(), snapshot.section);
   assertEquals(placement.rank.toString(), snapshot.rank);
 
   const roundTrip = placement.toJSON();
@@ -61,7 +61,7 @@ Deno.test("parsePlacement parses snapshot payload", () => {
 
 Deno.test("createRootPlacement produces immutable placement", () => {
   const placement = createRootPlacement(sampleSection, sampleRank);
-  assert(placement.kind === "root", "expected root placement");
+  assert(placement.kind() === "root", "expected root placement");
   assert(Object.isFrozen(placement), "placement should be frozen");
   const snapshot = placement.toJSON();
   assert(snapshot.kind === "root", "expected root snapshot");
@@ -70,7 +70,7 @@ Deno.test("createRootPlacement produces immutable placement", () => {
 
 Deno.test("createItemPlacement produces immutable placement", () => {
   const placement = createItemPlacement(sampleParentId, sampleSection, sampleRank);
-  assert(placement.kind === "item", "expected item placement");
+  assert(placement.kind() === "item", "expected item placement");
   assert(Object.isFrozen(placement), "placement should be frozen");
   const snapshot = placement.toJSON();
   assert(snapshot.kind === "item", "expected item snapshot");

--- a/src/domain/repositories/item_repository.ts
+++ b/src/domain/repositories/item_repository.ts
@@ -1,5 +1,6 @@
 import { Result } from "../../shared/result.ts";
 import { Item } from "../models/item.ts";
+import { PlacementBin } from "../models/placement.ts";
 import { ItemId } from "../primitives/mod.ts";
 import { ItemShortId } from "../primitives/item_short_id.ts";
 import { RepositoryError } from "./repository_error.ts";
@@ -9,6 +10,9 @@ export interface ItemRepository {
   load(id: ItemId): Promise<Result<Item | undefined, RepositoryError>>;
   save(item: Item): Promise<Result<void, RepositoryError>>;
   delete(id: ItemId): Promise<Result<void, RepositoryError>>;
+  listByPlacementBin(
+    bin: PlacementBin,
+  ): Promise<Result<ReadonlyArray<Item>, RepositoryError>>;
   findByShortId(
     shortId: ItemShortId,
   ): Promise<Result<Item | undefined, RepositoryError | AmbiguousShortIdError>>;

--- a/src/domain/services/item_resolution_service_test.ts
+++ b/src/domain/services/item_resolution_service_test.ts
@@ -5,6 +5,7 @@ import { ItemRepository } from "../repositories/item_repository.ts";
 import { Result } from "../../shared/result.ts";
 import { AmbiguousShortIdError } from "../repositories/short_id_resolution_error.ts";
 import { ItemId, ItemShortId } from "../primitives/mod.ts";
+import { PlacementBin } from "../models/placement.ts";
 
 // Mock item for testing
 const createMockItem = (id: string, title: string): Item => {
@@ -36,6 +37,7 @@ const createMockRepository = (items: Item[]): ItemRepository => ({
   },
   save: (_item: Item) => Promise.resolve(Result.ok(undefined)),
   delete: (_id: ItemId) => Promise.resolve(Result.ok(undefined)),
+  listByPlacementBin: (_bin: PlacementBin) => Promise.resolve(Result.ok(items)),
   findByShortId: (shortId: ItemShortId) => {
     const shortIdStr = shortId.toString();
     const matching = items.filter((item) => item.data.id.toString().endsWith(shortIdStr));

--- a/src/domain/workflows/change_item_status_test.ts
+++ b/src/domain/workflows/change_item_status_test.ts
@@ -18,7 +18,7 @@ import { ItemId } from "../primitives/item_id.ts";
 import { ItemShortId } from "../primitives/item_short_id.ts";
 import { RepositoryError } from "../repositories/repository_error.ts";
 import { AmbiguousShortIdError } from "../repositories/short_id_resolution_error.ts";
-import { createRootPlacement } from "../models/placement.ts";
+import { createRootPlacement, PlacementBin } from "../models/placement.ts";
 
 // Mock ItemRepository for testing
 class MockItemRepository implements ItemRepository {
@@ -40,6 +40,16 @@ class MockItemRepository implements ItemRepository {
   delete(id: ItemId): Promise<Result<void, RepositoryError>> {
     this.items.delete(id.toString());
     return Promise.resolve(Result.ok(undefined));
+  }
+
+  listByPlacementBin(
+    bin: PlacementBin,
+  ): Promise<Result<ReadonlyArray<Item>, RepositoryError>> {
+    const items = Array.from(this.items.values())
+      .filter((item) => item.data.placement.belongsTo(bin))
+      .sort((first, second) => first.data.placement.rank.compare(second.data.placement.rank));
+
+    return Promise.resolve(Result.ok(items));
   }
 
   findByShortId(

--- a/src/domain/workflows/create_item_test.ts
+++ b/src/domain/workflows/create_item_test.ts
@@ -1,0 +1,175 @@
+import { assertEquals } from "@std/assert";
+import { CreateItemWorkflow } from "./create_item.ts";
+import { Result } from "../../shared/result.ts";
+import { ItemRepository } from "../repositories/item_repository.ts";
+import { Item } from "../models/item.ts";
+import { ItemId } from "../primitives/item_id.ts";
+import { ItemShortId } from "../primitives/item_short_id.ts";
+import { createRootPlacement, createRootPlacementBin, PlacementBin } from "../models/placement.ts";
+import { createItem } from "../models/item.ts";
+import {
+  createItemIcon,
+  dateTimeFromDate,
+  itemIdFromString,
+  itemRankFromString,
+  itemStatusOpen,
+  itemTitleFromString,
+  parseCalendarDay,
+  parseSectionPath,
+} from "../primitives/mod.ts";
+import { createRankService, RankGenerator, RankService } from "../services/rank_service.ts";
+import { createIdGenerationService } from "../services/id_generation_service.ts";
+import { parseDateTime } from "../primitives/date_time.ts";
+
+class InMemoryItemRepository implements ItemRepository {
+  private readonly items = new Map<string, Item>();
+
+  load(id: ItemId) {
+    return Promise.resolve(Result.ok(this.items.get(id.toString())));
+  }
+
+  save(item: Item) {
+    this.items.set(item.data.id.toString(), item);
+    return Promise.resolve(Result.ok(undefined));
+  }
+
+  delete(id: ItemId) {
+    this.items.delete(id.toString());
+    return Promise.resolve(Result.ok(undefined));
+  }
+
+  listByPlacementBin(bin: PlacementBin) {
+    const siblings = Array.from(this.items.values())
+      .filter((item) => item.data.placement.belongsTo(bin))
+      .sort((first, second) => first.data.placement.rank.compare(second.data.placement.rank));
+
+    return Promise.resolve(Result.ok(siblings));
+  }
+
+  findByShortId(_shortId: ItemShortId) {
+    return Promise.resolve(Result.ok(undefined));
+  }
+
+  set(item: Item) {
+    this.items.set(item.data.id.toString(), item);
+  }
+}
+
+const createTestRankService = (): RankService => {
+  const generator: RankGenerator = {
+    min: () => "a",
+    max: () => "z",
+    middle: () => "m",
+    between: (first) => `${first}n`,
+    next: (rank) => `${rank}n`,
+    prev: (rank) => `${rank}p`,
+    compare: (first, second) => first.localeCompare(second),
+  };
+
+  return createRankService(generator);
+};
+
+const createFixedIdService = (id: string) =>
+  createIdGenerationService({
+    generate: () => id,
+  });
+
+const createExistingItem = (id: string, rank: string, section: string): Item => {
+  const itemId = Result.unwrap(itemIdFromString(id));
+  const title = Result.unwrap(itemTitleFromString("Existing"));
+  const icon = createItemIcon("note");
+  const status = itemStatusOpen();
+  const sectionPath = Result.unwrap(parseSectionPath(`:${section}`));
+  const placementRank = Result.unwrap(itemRankFromString(rank));
+  const placement = createRootPlacement(sectionPath, placementRank);
+  const createdAt = Result.unwrap(parseDateTime("2024-09-20T12:00:00Z"));
+
+  return createItem({
+    id: itemId,
+    title,
+    icon,
+    status,
+    placement,
+    createdAt,
+    updatedAt: createdAt,
+  });
+};
+
+Deno.test("CreateItemWorkflow assigns middle rank when section is empty", async () => {
+  const repository = new InMemoryItemRepository();
+  const rankService = createTestRankService();
+  const idService = createFixedIdService("019965a7-2789-740a-b8c1-1415904fd120");
+
+  const day = Result.unwrap(parseCalendarDay("2024-09-20"));
+  const createdAt = Result.unwrap(dateTimeFromDate(new Date("2024-09-20T12:00:00Z")));
+
+  const result = await CreateItemWorkflow.execute({
+    title: "New note",
+    itemType: "note",
+    day,
+    createdAt,
+  }, {
+    itemRepository: repository,
+    rankService,
+    idGenerationService: idService,
+  });
+
+  if (result.type !== "ok") {
+    throw new Error(`expected ok result, received ${JSON.stringify(result.error)}`);
+  }
+
+  assertEquals(result.value.item.data.placement.rank.toString(), "m");
+
+  const listResult = await repository.listByPlacementBin(
+    createRootPlacementBin(Result.unwrap(parseSectionPath(":2024-09-20"))),
+  );
+  if (listResult.type !== "ok") {
+    throw new Error(`expected ok list result, received ${JSON.stringify(listResult.error)}`);
+  }
+  assertEquals(listResult.value.length, 1);
+});
+
+Deno.test("CreateItemWorkflow appends rank after existing siblings", async () => {
+  const repository = new InMemoryItemRepository();
+  const rankService = createTestRankService();
+  const idService = createFixedIdService("019965a7-2789-740a-b8c1-1415904fd121");
+
+  const existing = createExistingItem(
+    "019965a7-2789-740a-b8c1-1415904fd110",
+    "m",
+    "2024-09-20",
+  );
+  Result.unwrap(await repository.save(existing));
+
+  const day = Result.unwrap(parseCalendarDay("2024-09-20"));
+  const createdAt = Result.unwrap(dateTimeFromDate(new Date("2024-09-20T13:00:00Z")));
+
+  const result = await CreateItemWorkflow.execute({
+    title: "Follow-up",
+    itemType: "note",
+    day,
+    createdAt,
+  }, {
+    itemRepository: repository,
+    rankService,
+    idGenerationService: idService,
+  });
+
+  if (result.type !== "ok") {
+    throw new Error(`expected ok result, received ${JSON.stringify(result.error)}`);
+  }
+
+  assertEquals(result.value.item.data.placement.rank.toString(), "mn");
+
+  const listResult = await repository.listByPlacementBin(
+    createRootPlacementBin(Result.unwrap(parseSectionPath(":2024-09-20"))),
+  );
+  if (listResult.type !== "ok") {
+    throw new Error(`expected ok list result, received ${JSON.stringify(listResult.error)}`);
+  }
+  assertEquals(listResult.value.length, 2);
+  assertEquals(
+    listResult.value.map((item) => item.data.placement.rank.toString()),
+    ["m", "mn"],
+  );
+});


### PR DESCRIPTION
# Changes

- Recast Placement as a bin + rank model with instance methods (kind(), parentId(), section(), belongsTo()), eliminating the old helper exports.
- Updated dependent code—workflows, repositories, and tests—to call these new methods instead of free functions (create_item.ts, item.ts, item_repository.ts, change_item_status_test.ts, create_item_test.ts, etc.).
- Adjusted redesign docs to describe <parent[:section]> as “Placement bins” and refreshed the plan snapshot to match the current state.
