### PR TITLE
feat: add placement model and section edge support

### DIFF
--- a/src/domain/models/edge.ts
+++ b/src/domain/models/edge.ts
@@ -19,9 +19,18 @@ import {
   parseItemId,
   parseItemRank,
 } from "../primitives/mod.ts";
+import {
+  createLegacyPlacement,
+  Placement,
+  PlacementSnapshot,
+  placementLegacyContainer,
+  placementToSnapshot,
+  parsePlacementSnapshot,
+} from "./placement.ts";
 
 const CONTAINER_EDGE_KIND = "ContainerEdge" as const;
 const ITEM_EDGE_KIND = "ItemEdge" as const;
+const SECTION_EDGE_KIND = "SectionEdge" as const;
 const EDGE_KIND = "Edge" as const;
 
 type ContainerEdgeData = Readonly<{
@@ -32,6 +41,11 @@ type ContainerEdgeData = Readonly<{
 type ItemEdgeData = Readonly<{
   readonly to: ItemId;
   readonly rank: ItemRank;
+}>;
+
+type SectionEdgeData = Readonly<{
+  readonly to: ItemId;
+  readonly placement: Placement;
 }>;
 
 export type ContainerEdge = Readonly<{
@@ -46,7 +60,13 @@ export type ItemEdge = Readonly<{
   toJSON(): ItemEdgeSnapshot;
 }>;
 
-export type Edge = ContainerEdge | ItemEdge;
+export type SectionEdge = Readonly<{
+  readonly kind: typeof SECTION_EDGE_KIND;
+  readonly data: SectionEdgeData;
+  toJSON(): SectionEdgeSnapshot;
+}>;
+
+export type Edge = ContainerEdge | ItemEdge | SectionEdge;
 
 export type ContainerEdgeSnapshot = Readonly<{
   readonly kind?: typeof CONTAINER_EDGE_KIND;
@@ -60,10 +80,23 @@ export type ItemEdgeSnapshot = Readonly<{
   readonly rank: string;
 }>;
 
-export type EdgeSnapshot = ContainerEdgeSnapshot | ItemEdgeSnapshot;
+export type SectionEdgeSnapshot = Readonly<{
+  readonly kind?: typeof SECTION_EDGE_KIND;
+  readonly to: string;
+  readonly rank: string;
+  readonly container: string;
+  readonly parentId?: string;
+  readonly placement?: PlacementSnapshot;
+}>;
+
+export type EdgeSnapshot =
+  | ContainerEdgeSnapshot
+  | ItemEdgeSnapshot
+  | SectionEdgeSnapshot;
 
 export type ContainerEdgeValidationError = ValidationError<typeof CONTAINER_EDGE_KIND>;
 export type ItemEdgeValidationError = ValidationError<typeof ITEM_EDGE_KIND>;
+export type SectionEdgeValidationError = ValidationError<typeof SECTION_EDGE_KIND>;
 export type EdgeValidationError = ValidationError<typeof EDGE_KIND>;
 
 const instantiateContainerEdge = (data: ContainerEdgeData): ContainerEdge => {
@@ -96,6 +129,26 @@ const instantiateItemEdge = (data: ItemEdgeData): ItemEdge => {
   });
 };
 
+const instantiateSectionEdge = (data: SectionEdgeData): SectionEdge => {
+  const frozen = Object.freeze({ ...data });
+  const placementSnapshot = placementToSnapshot(frozen.placement);
+  const legacyContainer = placementLegacyContainer(frozen.placement);
+  return Object.freeze({
+    kind: SECTION_EDGE_KIND,
+    data: frozen,
+    toJSON() {
+      return Object.freeze({
+        kind: SECTION_EDGE_KIND,
+        to: frozen.to.toString(),
+        rank: frozen.placement.rank.toString(),
+        container: legacyContainer?.toString() ?? "",
+        parentId: placementSnapshot.parentId,
+        placement: placementSnapshot,
+      });
+    },
+  });
+};
+
 const prefixIssues = (
   field: string,
   error:
@@ -121,8 +174,32 @@ export const createItemEdge = (
   rank: ItemRank,
 ): ItemEdge => instantiateItemEdge({ to, rank });
 
+export const createSectionEdge = (
+  to: ItemId,
+  placement: Placement,
+): SectionEdge => instantiateSectionEdge({ to, placement });
+
 export const isItemEdge = (edge: Edge): edge is ItemEdge => edge.kind === "ItemEdge";
 export const isContainerEdge = (edge: Edge): edge is ContainerEdge => edge.kind === "ContainerEdge";
+export const isSectionEdge = (edge: Edge): edge is SectionEdge => edge.kind === "SectionEdge";
+
+export const sectionEdgeFromLegacy = (
+  container: ContainerPath,
+  edge: ItemEdge,
+): SectionEdge =>
+  createSectionEdge(edge.data.to, createLegacyPlacement(container, edge.data.rank));
+
+export const legacyDetailsFromSectionEdge = (
+  edge: SectionEdge,
+): Readonly<{
+  readonly container?: ContainerPath;
+  readonly rank: ItemRank;
+  readonly child: ItemId;
+}> => ({
+  container: placementLegacyContainer(edge.data.placement),
+  rank: edge.data.placement.rank,
+  child: edge.data.to,
+});
 
 export const parseContainerEdge = (
   input: unknown,
@@ -234,6 +311,81 @@ export const parseItemEdge = (
   return Result.ok(instantiateItemEdge({ to, rank }));
 };
 
+export const parseSectionEdge = (
+  input: unknown,
+): Result<SectionEdge, SectionEdgeValidationError> => {
+  if (typeof input !== "object" || input === null) {
+    return Result.error(
+      createValidationError(SECTION_EDGE_KIND, [
+        createValidationIssue("edge must be an object", { path: ["value"], code: "type" }),
+      ]),
+    );
+  }
+
+  const snapshot = input as SectionEdgeSnapshot;
+  const issues: ValidationIssue[] = [];
+
+  let child: ItemId | undefined;
+  if ("to" in snapshot) {
+    const result = parseItemId(snapshot.to);
+    if (result.type === "error") {
+      issues.push(...prefixIssues("to", result.error));
+    } else {
+      child = result.value;
+    }
+  } else {
+    issues.push(createValidationIssue("to is required", { path: ["to"], code: "required" }));
+  }
+
+  let rank: ItemRank | undefined;
+  if ("rank" in snapshot) {
+    const result = parseItemRank(snapshot.rank);
+    if (result.type === "error") {
+      issues.push(...prefixIssues("rank", result.error));
+    } else {
+      rank = result.value;
+    }
+  } else {
+    issues.push(createValidationIssue("rank is required", { path: ["rank"], code: "required" }));
+  }
+
+  let containerPath: ContainerPath | undefined;
+  if ("container" in snapshot) {
+    const result = parseContainerPath(snapshot.container);
+    if (result.type === "error") {
+      issues.push(...prefixIssues("container", result.error));
+    } else {
+      containerPath = result.value;
+    }
+  } else {
+    issues.push(createValidationIssue("container is required", { path: ["container"], code: "required" }));
+  }
+
+  if (issues.length > 0 || !child || !rank || !containerPath) {
+    return Result.error(createValidationError(SECTION_EDGE_KIND, issues));
+  }
+
+  const placementSnapshot: PlacementSnapshot = snapshot.placement ?? {
+    kind: "legacy",
+    container: snapshot.container,
+    parentId: snapshot.parentId,
+  };
+
+  const placementResult = parsePlacementSnapshot(
+    placementSnapshot,
+    containerPath,
+    rank,
+  );
+
+  if (placementResult.type === "error") {
+    return Result.error(
+      createValidationError(SECTION_EDGE_KIND, placementResult.error.issues),
+    );
+  }
+
+  return Result.ok(instantiateSectionEdge({ to: child, placement: placementResult.value }));
+};
+
 export const parseEdge = (
   input: EdgeSnapshot | unknown,
 ): Result<Edge, EdgeValidationError> => {
@@ -264,8 +416,24 @@ export const parseEdge = (
     return Result.ok(result.value);
   }
 
+  if (kind === SECTION_EDGE_KIND) {
+    const result = parseSectionEdge(candidate);
+    if (result.type === "error") {
+      return Result.error(createValidationError(EDGE_KIND, result.error.issues));
+    }
+    return Result.ok(result.value);
+  }
+
   if ("index" in candidate && "to" in candidate) {
     const result = parseContainerEdge(candidate);
+    if (result.type === "error") {
+      return Result.error(createValidationError(EDGE_KIND, result.error.issues));
+    }
+    return Result.ok(result.value);
+  }
+
+  if ("rank" in candidate && "container" in candidate && "to" in candidate) {
+    const result = parseSectionEdge(candidate);
     if (result.type === "error") {
       return Result.error(createValidationError(EDGE_KIND, result.error.issues));
     }

--- a/src/domain/models/edge_test.ts
+++ b/src/domain/models/edge_test.ts
@@ -1,9 +1,25 @@
-import { parseContainerEdge, parseEdge, parseItemEdge } from "./edge.ts";
+import {
+  parseContainerEdge,
+  parseEdge,
+  parseItemEdge,
+  parseSectionEdge,
+  sectionEdgeFromLegacy,
+} from "./edge.ts";
 
 const assertEquals = <T>(actual: T, expected: T, message?: string): void => {
   if (actual !== expected) {
     throw new Error(message ?? `expected ${expected} but received ${actual}`);
   }
+};
+
+const unwrapOk = <T, E>(
+  result: { type: "ok"; value: T } | { type: "error"; error: E },
+  context: string,
+): T => {
+  if (result.type !== "ok") {
+    throw new Error(`${context}: ${JSON.stringify(result.error)}`);
+  }
+  return result.value;
 };
 
 Deno.test("parseContainerEdge parses valid snapshot", () => {
@@ -50,6 +66,36 @@ Deno.test("parseItemEdge parses valid snapshot", () => {
   assertEquals(snapshot.rank, "a1");
 });
 
+Deno.test("parseSectionEdge parses legacy snapshot", () => {
+  const result = parseSectionEdge({
+    kind: "SectionEdge",
+    to: "019965a7-2789-740a-b8c1-1415904fd108",
+    rank: "a1",
+    container: "projects/focus",
+    placement: { kind: "legacy", container: "projects/focus" },
+  });
+
+  if (result.type !== "ok") {
+    throw new Error(`expected ok, got error: ${JSON.stringify(result.error)}`);
+  }
+
+  const edge = result.value;
+  assertEquals(edge.kind, "SectionEdge");
+  assertEquals(edge.data.to.toString(), "019965a7-2789-740a-b8c1-1415904fd108");
+  const container = edge.data.placement.section.kind === "legacy"
+    ? edge.data.placement.section.container.toString()
+    : undefined;
+  assertEquals(container, "projects/focus");
+  assertEquals(edge.data.placement.rank.toString(), "a1");
+
+  const snapshot = edge.toJSON();
+  assertEquals(snapshot.kind, "SectionEdge");
+  assertEquals(snapshot.to, "019965a7-2789-740a-b8c1-1415904fd108");
+  assertEquals(snapshot.rank, "a1");
+  assertEquals(snapshot.container, "projects/focus");
+  assert(snapshot.placement !== undefined, "placement snapshot should be persisted");
+});
+
 Deno.test("parseItemEdge rejects missing rank", () => {
   const result = parseItemEdge({
     kind: "ItemEdge",
@@ -77,6 +123,41 @@ Deno.test("parseEdge dispatches based on kind", () => {
   }
 
   assertEquals(result.value.kind, "ItemEdge");
+});
+
+Deno.test("parseEdge handles section edge without explicit kind", () => {
+  const result = parseEdge({
+    to: "019965a7-2789-740a-b8c1-1415904fd108",
+    rank: "a1",
+    container: "projects/focus",
+  });
+
+  if (result.type !== "ok") {
+    throw new Error(`expected ok, got error: ${JSON.stringify(result.error)}`);
+  }
+
+  assertEquals(result.value.kind, "SectionEdge");
+});
+
+Deno.test("sectionEdgeFromLegacy composes placement", () => {
+  const itemEdge = unwrapOk(parseItemEdge({
+    kind: "ItemEdge",
+    to: "019965a7-2789-740a-b8c1-1415904fd108",
+    rank: "a1",
+  }), "parse item edge");
+  const containerResult = parseContainerEdge({
+    kind: "ContainerEdge",
+    to: "projects/focus",
+    index: 1,
+  });
+  const containerPath = unwrapOk(containerResult, "parse container").data.to;
+  const sectionEdge = sectionEdgeFromLegacy(containerPath, itemEdge);
+  assertEquals(sectionEdge.kind, "SectionEdge");
+  const container = sectionEdge.data.placement.section.kind === "legacy"
+    ? sectionEdge.data.placement.section.container.toString()
+    : undefined;
+  assertEquals(container, "projects/focus");
+  assertEquals(sectionEdge.data.placement.rank.toString(), "a1");
 });
 
 Deno.test("parseEdge rejects unknown payload", () => {

--- a/src/domain/models/placement.ts
+++ b/src/domain/models/placement.ts
@@ -1,0 +1,195 @@
+import { Result } from "../../shared/result.ts";
+import {
+  createValidationError,
+  createValidationIssue,
+  ValidationError,
+  ValidationIssue,
+} from "../../shared/errors.ts";
+import {
+  ContainerPath,
+  ContainerPathValidationError,
+  parseContainerPath,
+} from "../primitives/container_path.ts";
+import { ItemId, ItemIdValidationError, parseItemId } from "../primitives/item_id.ts";
+import { ItemRank } from "../primitives/item_rank.ts";
+
+const PLACEMENT_KIND = "Placement" as const;
+const LEGACY_SECTION_KIND = "legacy" as const;
+
+type PlacementSection = LegacyPlacementSection;
+
+export type LegacyPlacementSection = Readonly<{
+  readonly kind: typeof LEGACY_SECTION_KIND;
+  readonly container: ContainerPath;
+}>;
+
+export type Placement = Readonly<{
+  readonly parentId?: ItemId;
+  readonly section: PlacementSection;
+  readonly rank: ItemRank;
+}>;
+
+export type PlacementSnapshot =
+  | LegacyPlacementSnapshot;
+
+export type LegacyPlacementSnapshot = Readonly<{
+  readonly kind?: typeof LEGACY_SECTION_KIND;
+  readonly parentId?: string;
+  readonly container: string;
+}>;
+
+export type PlacementValidationError = ValidationError<typeof PLACEMENT_KIND>;
+
+type SectionParseResult = Result<PlacementSection, PlacementValidationError>;
+
+type SectionSnapshot = PlacementSnapshot & { kind?: string };
+
+const prefixIssues = (
+  field: string,
+  error:
+    | ItemIdValidationError
+    | ContainerPathValidationError,
+): ValidationIssue[] =>
+  error.issues.map((issue) =>
+    createValidationIssue(issue.message, {
+      code: issue.code,
+      path: [field, ...issue.path],
+    })
+  );
+
+const parseLegacySection = (
+  snapshot: LegacyPlacementSnapshot,
+): SectionParseResult => {
+  if (!("container" in snapshot)) {
+    return Result.error(
+      createValidationError(PLACEMENT_KIND, [
+        createValidationIssue("container is required", {
+          path: ["placement", "container"],
+          code: "required",
+        }),
+      ]),
+    );
+  }
+
+  const containerResult = parseContainerPath(snapshot.container);
+  if (containerResult.type === "error") {
+    return Result.error(
+      createValidationError(PLACEMENT_KIND, prefixIssues("placement", containerResult.error)),
+    );
+  }
+
+  return Result.ok(Object.freeze({
+    kind: LEGACY_SECTION_KIND,
+    container: containerResult.value,
+  }));
+};
+
+const parseSectionSnapshot = (
+  snapshot: SectionSnapshot,
+): SectionParseResult => {
+  const kind = snapshot.kind ?? LEGACY_SECTION_KIND;
+  if (kind === LEGACY_SECTION_KIND) {
+    return parseLegacySection(snapshot as LegacyPlacementSnapshot);
+  }
+
+  return Result.error(
+    createValidationError(PLACEMENT_KIND, [
+      createValidationIssue("placement kind is not supported", {
+        path: ["placement", "kind"],
+        code: "unknown_variant",
+      }),
+    ]),
+  );
+};
+
+export const createLegacyPlacement = (
+  container: ContainerPath,
+  rank: ItemRank,
+  parentId?: ItemId,
+): Placement =>
+  Object.freeze({
+    parentId,
+    section: Object.freeze({
+      kind: LEGACY_SECTION_KIND,
+      container,
+    }),
+    rank,
+  });
+
+export const placementEquals = (left: Placement, right: Placement): boolean => {
+  const sameParent = left.parentId?.toString() === right.parentId?.toString();
+  const sameRank = left.rank.compare(right.rank) === 0;
+  if (left.section.kind === LEGACY_SECTION_KIND && right.section.kind === LEGACY_SECTION_KIND) {
+    const leftContainer = left.section.container.toString();
+    const rightContainer = right.section.container.toString();
+    return sameParent && sameRank && leftContainer === rightContainer;
+  }
+  return sameParent && sameRank && left.section.kind === right.section.kind;
+};
+
+export const placementLegacyContainer = (
+  placement: Placement,
+): ContainerPath | undefined => {
+  if (placement.section.kind === LEGACY_SECTION_KIND) {
+    return placement.section.container;
+  }
+  return undefined;
+};
+
+export const placementToSnapshot = (
+  placement: Placement,
+): PlacementSnapshot => {
+  if (placement.section.kind === LEGACY_SECTION_KIND) {
+    return Object.freeze({
+      kind: LEGACY_SECTION_KIND,
+      parentId: placement.parentId?.toString(),
+      container: placement.section.container.toString(),
+    });
+  }
+
+  return Object.freeze({
+    kind: LEGACY_SECTION_KIND,
+    parentId: placement.parentId?.toString(),
+    container: placement.section.kind,
+  });
+};
+
+export const parsePlacementSnapshot = (
+  snapshot: PlacementSnapshot | undefined,
+  fallbackContainer: ContainerPath,
+  rank: ItemRank,
+): Result<Placement, PlacementValidationError> => {
+  if (!snapshot) {
+    return Result.ok(createLegacyPlacement(fallbackContainer, rank));
+  }
+
+  const sectionResult = parseSectionSnapshot(snapshot as SectionSnapshot);
+  if (sectionResult.type === "error") {
+    return sectionResult;
+  }
+
+  let parentId: ItemId | undefined;
+  if (snapshot.parentId !== undefined) {
+    const parentResult = parseItemId(snapshot.parentId);
+    if (parentResult.type === "error") {
+      return Result.error(
+        createValidationError(PLACEMENT_KIND, prefixIssues("placement", parentResult.error)),
+      );
+    }
+    parentId = parentResult.value;
+  }
+
+  const section = sectionResult.value;
+  if (section.kind === LEGACY_SECTION_KIND) {
+    return Result.ok(createLegacyPlacement(section.container, rank, parentId));
+  }
+
+  return Result.error(
+    createValidationError(PLACEMENT_KIND, [
+      createValidationIssue("placement kind is not supported", {
+        path: ["placement", "kind"],
+        code: "unknown_variant",
+      }),
+    ]),
+  );
+};

--- a/src/domain/workflows/change_item_status_test.ts
+++ b/src/domain/workflows/change_item_status_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { ChangeItemStatusWorkflow } from "./change_item_status.ts";
 import { createItem } from "../models/item.ts";
+import { createLegacyPlacement } from "../models/placement.ts";
 import {
   containerPathFromSegments,
   createItemIcon,
@@ -84,6 +85,7 @@ function createTestItem(id: string, status: "open" | "closed" = "open") {
   const itemStatus = status === "open" ? itemStatusOpen() : itemStatusClosed();
   const container = Result.unwrap(containerPathFromSegments(["2024", "01", "01"]));
   const rank = Result.unwrap(itemRankFromString("a0"));
+  const placement = createLegacyPlacement(container, rank);
   const now = Result.unwrap(dateTimeFromDate(new Date()));
 
   return createItem({
@@ -91,8 +93,7 @@ function createTestItem(id: string, status: "open" | "closed" = "open") {
     title,
     icon,
     status: itemStatus,
-    container,
-    rank,
+    placement,
     createdAt: now,
     updatedAt: now,
     closedAt: status === "closed" ? now : undefined,

--- a/src/domain/workflows/create_item.ts
+++ b/src/domain/workflows/create_item.ts
@@ -2,6 +2,7 @@ import { Result } from "../../shared/result.ts";
 import { createValidationIssue, ValidationIssue } from "../../shared/errors.ts";
 import { Item } from "../models/item.ts";
 import { createItem } from "../models/item.ts";
+import { createLegacyPlacement } from "../models/placement.ts";
 import {
   ContainerPath,
   containerPathFromSegments,
@@ -182,13 +183,14 @@ export const CreateItemWorkflow = {
     const trimmedBody = typeof input.body === "string" ? input.body.trim() : undefined;
     const body = trimmedBody && trimmedBody.length > 0 ? trimmedBody : undefined;
 
+    const placement = createLegacyPlacement(resolvedContainerPath, rankResult.value);
+
     const item = createItem({
       id: resolvedId,
       title: resolvedTitle,
       icon: createItemIcon(input.itemType),
       status: itemStatusOpen(),
-      container: resolvedContainerPath,
-      rank: rankResult.value,
+      placement,
       createdAt: input.createdAt,
       updatedAt: input.createdAt,
       body,

--- a/src/infrastructure/fileSystem/item_repository_test.ts
+++ b/src/infrastructure/fileSystem/item_repository_test.ts
@@ -58,7 +58,14 @@ Deno.test({
       const metaSnapshot = JSON.parse(await Deno.readTextFile(metaPath));
       assertEquals(metaSnapshot.schema, "mm.item/1");
       assertEquals(metaSnapshot.id, itemId);
-      assertEquals(metaSnapshot.rank, item.data.rank.toString());
+      assertEquals(metaSnapshot.rank, item.data.placement.rank.toString());
+      if (item.data.placement.section.kind === "legacy") {
+        assert(metaSnapshot.placement !== undefined, "placement metadata should be present");
+        assertEquals(
+          metaSnapshot.placement?.container,
+          item.data.placement.section.container.toString(),
+        );
+      }
 
       const content = await Deno.readTextFile(contentPath);
       assertEquals(content, "Sample body\n");


### PR DESCRIPTION
## Summary
- introduce a Placement model to capture parent/section/rank data and attach it to Item snapshots
- extend edge handling with SectionEdge support and helpers for legacy container paths
- update workflows, repositories, and tests to use placements and persist placement metadata on disk

## Testing
- Not run (Deno CLI unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d248524db88324991110349047654c