### PR TITLE
feat(cli): improve command ergonomics for daily use

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,9 +9,9 @@ import { createReopenCommand } from "./presentation/cli/commands/reopen.ts";
 import { createWorkspaceCommand } from "./presentation/cli/commands/workspace.ts";
 import { createCdCommand } from "./presentation/cli/commands/cd.ts";
 import { createPwdCommand } from "./presentation/cli/commands/pwd.ts";
-import { createLsCommand } from "./presentation/cli/commands/ls.ts";
+import { createListCommand } from "./presentation/cli/commands/list.ts";
 import { createWhereCommand } from "./presentation/cli/commands/where.ts";
-import { createMvCommand } from "./presentation/cli/commands/mv.ts";
+import { createMoveCommand } from "./presentation/cli/commands/move.ts";
 import { createDoctorCommand } from "./presentation/cli/commands/doctor/mod.ts";
 import { createEditCommand } from "./presentation/cli/commands/edit.ts";
 import { createSnoozeCommand } from "./presentation/cli/commands/snooze.ts";
@@ -24,18 +24,18 @@ async function main() {
     .command("note", createNoteCommand().description("Create a new note")).alias("n")
     .command("task", createTaskCommand().description("Create a new task")).alias("t")
     .command("event", createEventCommand().description("Create a new event")).alias("ev")
-    .command("close", createCloseCommand().description("Close items"))
-    .command("reopen", createReopenCommand().description("Reopen closed items"))
+    .command("close", createCloseCommand().description("Close items")).alias("cl")
+    .command("reopen", createReopenCommand().description("Reopen closed items")).alias("op")
     .command("edit", createEditCommand().description("Edit an item")).alias("e")
     .command("workspace", createWorkspaceCommand().description("Workspace management")).alias("ws")
     .command("cd", createCdCommand().description("Change current working directory"))
     .command("pwd", createPwdCommand().description("Print current working directory"))
-    .command("ls", createLsCommand().description("List items"))
+    .command("list", createListCommand().description("List items")).alias("ls")
     .command(
       "where",
       createWhereCommand().description("Show logical and physical paths for an item"),
     )
-    .command("mv", createMvCommand().description("Move item to a new placement"))
+    .command("move", createMoveCommand().description("Move items to a new placement")).alias("mv")
     .command("snooze", createSnoozeCommand().description("Snooze item until a future datetime"))
     .alias("sn")
     .command("doctor", createDoctorCommand().description("Workspace validation and maintenance"));

--- a/src/presentation/cli/commands/edit.ts
+++ b/src/presentation/cli/commands/edit.ts
@@ -46,7 +46,7 @@ const formatItem = (
 export function createEditCommand() {
   return new Command()
     .description("Edit an item")
-    .arguments("<locator:string>")
+    .arguments("<id:string>")
     .option("--title <title:string>", "Update title")
     .option("--icon <icon:string>", "Update icon")
     .option("--body <body:string>", "Update body")
@@ -56,7 +56,7 @@ export function createEditCommand() {
     .option("--alias <alias:string>", "Update alias")
     .option("-c, --context <context:string>", "Update context tag")
     .option("-w, --workspace <workspace:string>", "Workspace to override")
-    .action(async (options: Record<string, unknown>, itemLocator: string) => {
+    .action(async (options: Record<string, unknown>, itemRef: string) => {
       const debug = isDebugMode();
       const workspaceOption = typeof options.workspace === "string" ? options.workspace : undefined;
       const depsResult = await loadCliDependencies(workspaceOption);
@@ -80,7 +80,7 @@ export function createEditCommand() {
       if (!hasMetadataOptions(options)) {
         const loadResult = await EditItemWorkflow.execute(
           {
-            itemLocator,
+            itemLocator: itemRef,
             updates: {},
             updatedAt: occurredAtResult.value,
             timezone: deps.timezone,
@@ -110,7 +110,7 @@ export function createEditCommand() {
         );
 
         if (!filePath) {
-          console.error(`Could not determine file path for item: ${itemLocator}`);
+          console.error(`Could not determine file path for item: ${itemRef}`);
           Deno.exit(1);
         }
 
@@ -212,7 +212,7 @@ export function createEditCommand() {
 
       const result = await EditItemWorkflow.execute(
         {
-          itemLocator,
+          itemLocator: itemRef,
           updates,
           updatedAt: occurredAtResult.value,
           timezone: deps.timezone,

--- a/src/presentation/cli/commands/edit_test.ts
+++ b/src/presentation/cli/commands/edit_test.ts
@@ -5,7 +5,7 @@ Deno.test("Edit command - should have correct structure", () => {
   const command = createEditCommand();
 
   assertEquals(command.getDescription(), "Edit an item");
-  assertEquals(command.getArguments()[0]?.name, "locator");
+  assertEquals(command.getArguments()[0]?.name, "id");
   assertEquals(command.getArguments()[0]?.type, "string");
 
   const options = command.getOptions();

--- a/src/presentation/cli/commands/list.ts
+++ b/src/presentation/cli/commands/list.ts
@@ -1,0 +1,359 @@
+import { Command, EnumType } from "@cliffy/command";
+import { loadCliDependencies } from "../dependencies.ts";
+import { ListItemsStatusFilter, ListItemsWorkflow } from "../../../domain/workflows/list_items.ts";
+import { CwdResolutionService } from "../../../domain/services/cwd_resolution_service.ts";
+import type { ItemIconValue } from "../../../domain/primitives/item_icon.ts";
+import { parseRangeExpression } from "../path_expression.ts";
+import { createPathResolver } from "../../../domain/services/path_resolver.ts";
+import {
+  createDateRange,
+  type PlacementRange,
+} from "../../../domain/primitives/placement_range.ts";
+import { parseCalendarDay } from "../../../domain/primitives/calendar_day.ts";
+import { createPlacement } from "../../../domain/primitives/placement.ts";
+import type { SectionSummary } from "../../../domain/services/section_query_service.ts";
+import { buildPartitions, formatWarning } from "../partitioning/build_partitions.ts";
+import {
+  formatDateHeader,
+  formatItemHeadHeader,
+  formatItemLine,
+  formatSectionStub,
+  type ListFormatterOptions,
+} from "../formatters/list_formatter.ts";
+import { outputWithPager } from "../pager.ts";
+import { formatError } from "../error_formatter.ts";
+import { isDebugMode } from "../debug.ts";
+
+type ListOptions = {
+  workspace?: string;
+  type?: ItemIconValue;
+  all?: boolean;
+  print?: boolean;
+  noPager?: boolean;
+};
+
+const itemTypeEnum = new EnumType(["note", "task", "event"]);
+
+const DEFAULT_DATE_WINDOW_DAYS = 7;
+
+/**
+ * Compute today's date in the given timezone.
+ */
+const computeTodayInTimezone = (now: Date, timezone: string): Date => {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(now);
+  const lookup = new Map(parts.map((part) => [part.type, part.value]));
+  return new Date(
+    Number(lookup.get("year")),
+    Number(lookup.get("month")) - 1,
+    Number(lookup.get("day")),
+  );
+};
+
+/**
+ * Add days to a date (handles month/year boundaries).
+ */
+const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+/**
+ * Format a Date as YYYY-MM-DD string.
+ */
+const formatDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export function createListCommand() {
+  return new Command()
+    .description("List items in current directory or target path")
+    .arguments("[locator:string]")
+    .type("itemType", itemTypeEnum)
+    .option("-w, --workspace <workspace:string>", "Workspace to override")
+    .option("-t, --type <type:itemType>", "Filter by item type (note, task, event)")
+    .option("-a, --all", "Include closed items")
+    .option("-p, --print", "Plain output without colors (includes ISO date)")
+    .option("--no-pager", "Do not use pager")
+    .action(async (options: ListOptions, locatorArg?: string) => {
+      const debug = isDebugMode();
+      const depsResult = await loadCliDependencies(options.workspace);
+      if (depsResult.type === "error") {
+        if (depsResult.error.type === "repository") {
+          console.error(formatError(depsResult.error.error, debug));
+        } else {
+          console.error(formatError(depsResult.error, debug));
+        }
+        return;
+      }
+
+      const deps = depsResult.value;
+      const now = new Date();
+
+      const cwdResult = await CwdResolutionService.getCwd(
+        {
+          stateRepository: deps.stateRepository,
+          itemRepository: deps.itemRepository,
+        },
+        now,
+      );
+
+      if (cwdResult.type === "error") {
+        console.error(formatError(cwdResult.error, debug));
+        return;
+      }
+
+      const cwd = cwdResult.value;
+      const statusFilter: ListItemsStatusFilter = options.all ? "all" : "open";
+      const isPrintMode = options.print === true;
+
+      // Resolve PlacementRange and effective expression for workflow
+      let placementRange: PlacementRange;
+      let effectiveExpression: string | undefined;
+
+      if (locatorArg) {
+        // Parse and resolve locator expression
+        const rangeExprResult = parseRangeExpression(locatorArg);
+        if (rangeExprResult.type === "error") {
+          console.error(formatError(rangeExprResult.error, debug));
+          return;
+        }
+
+        const pathResolver = createPathResolver({
+          aliasRepository: deps.aliasRepository,
+          itemRepository: deps.itemRepository,
+          timezone: deps.timezone,
+          today: now,
+        });
+
+        const resolveResult = await pathResolver.resolveRange(cwd, rangeExprResult.value);
+        if (resolveResult.type === "error") {
+          console.error(formatError(resolveResult.error, debug));
+          return;
+        }
+
+        placementRange = resolveResult.value;
+        effectiveExpression = locatorArg;
+      } else {
+        // If cwd is an item-head section, use cwd as the target
+        // Otherwise, default to today-7d..today+7d date range
+        if (cwd.head.kind === "item") {
+          placementRange = { kind: "single", at: cwd };
+          effectiveExpression = ".";
+        } else {
+          const todayResult = computeTodayInTimezone(now, deps.timezone.toString());
+          const fromDate = addDays(todayResult, -DEFAULT_DATE_WINDOW_DAYS);
+          const toDate = addDays(todayResult, DEFAULT_DATE_WINDOW_DAYS);
+
+          const fromDateStr = formatDateString(fromDate);
+          const toDateStr = formatDateString(toDate);
+
+          const fromResult = parseCalendarDay(fromDateStr);
+          const toResult = parseCalendarDay(toDateStr);
+
+          if (fromResult.type === "error" || toResult.type === "error") {
+            console.error("Failed to compute default date range");
+            return;
+          }
+
+          placementRange = createDateRange(fromResult.value, toResult.value);
+          // Build expression for workflow
+          effectiveExpression = `${fromDateStr}..${toDateStr}`;
+        }
+      }
+
+      // Execute workflow to get items
+      const workflowResult = await ListItemsWorkflow.execute(
+        {
+          expression: effectiveExpression,
+          cwd,
+          today: now,
+          timezone: deps.timezone,
+          status: statusFilter,
+          icon: options.type,
+        },
+        {
+          itemRepository: deps.itemRepository,
+          aliasRepository: deps.aliasRepository,
+        },
+      );
+
+      if (workflowResult.type === "error") {
+        console.error(formatError(workflowResult.error, debug));
+        return;
+      }
+
+      const { items } = workflowResult.value;
+
+      // Query sections for numeric ranges
+      let sections: ReadonlyArray<SectionSummary> = [];
+      if (placementRange.kind === "numericRange" || placementRange.kind === "single") {
+        const parent = placementRange.kind === "numericRange"
+          ? placementRange.parent
+          : placementRange.at;
+
+        const sectionsResult = await deps.sectionQueryService.listSections(parent);
+        if (sectionsResult.type === "error") {
+          console.error(`Failed to query sections: ${sectionsResult.error.message}`);
+          return;
+        }
+        sections = sectionsResult.value;
+      }
+
+      // Look up alias by item ID (simple implementation)
+      const aliasMap = new Map<string, string>();
+      for (const item of items) {
+        const alias = item.data.alias?.toString();
+        if (alias) {
+          aliasMap.set(item.data.id.toString(), alias);
+        }
+      }
+
+      // For item-head ranges, try to get the parent item's alias
+      if (
+        (placementRange.kind === "numericRange" || placementRange.kind === "single") &&
+        (placementRange.kind === "numericRange"
+          ? placementRange.parent.head.kind === "item"
+          : placementRange.at.head.kind === "item")
+      ) {
+        const parentId = placementRange.kind === "numericRange"
+          ? placementRange.parent.head.kind === "item"
+            ? placementRange.parent.head.id.toString()
+            : null
+          : placementRange.at.head.kind === "item"
+          ? placementRange.at.head.id.toString()
+          : null;
+
+        if (parentId && !aliasMap.has(parentId)) {
+          // Get the parent item ID from the placement range
+          const parentItemId = placementRange.kind === "numericRange" &&
+              placementRange.parent.head.kind === "item"
+            ? placementRange.parent.head.id
+            : placementRange.kind === "single" && placementRange.at.head.kind === "item"
+            ? placementRange.at.head.id
+            : null;
+
+          if (parentItemId) {
+            const parentItemResult = await deps.itemRepository.load(parentItemId);
+            if (parentItemResult.type === "ok" && parentItemResult.value) {
+              const parentAlias = parentItemResult.value.data.alias?.toString();
+              if (parentAlias) {
+                aliasMap.set(parentId, parentAlias);
+              }
+            }
+          }
+        }
+      }
+
+      const lookupAlias = (id: string): string | undefined => aliasMap.get(id);
+
+      // Build display label function for item sections
+      const getDisplayLabel = (
+        parent: ReturnType<typeof createPlacement>,
+        sectionPrefix: number,
+      ): string => {
+        const headStr = parent.head.kind === "date"
+          ? parent.head.date.toString()
+          : (lookupAlias(parent.head.id.toString()) ?? parent.head.id.toString());
+
+        if (parent.section.length === 0) {
+          return `${headStr}/${sectionPrefix}`;
+        }
+
+        return `${headStr}/${parent.section.join("/")}/${sectionPrefix}`;
+      };
+
+      // Build partitions
+      const partitionResult = buildPartitions({
+        items,
+        range: placementRange,
+        sections,
+        getDisplayLabel,
+      });
+
+      // Emit warnings to stderr
+      for (const warning of partitionResult.warnings) {
+        console.error(formatWarning(warning));
+      }
+
+      const { partitions } = partitionResult;
+
+      // Check for empty result
+      if (partitions.length === 0) {
+        console.log("(empty)");
+        return;
+      }
+
+      // Format and output
+      const formatterOptions: ListFormatterOptions = {
+        printMode: isPrintMode,
+        timezone: deps.timezone,
+      };
+
+      const outputLines: string[] = [];
+
+      for (const partition of partitions) {
+        // Format header
+        if (partition.header.kind === "date") {
+          outputLines.push(formatDateHeader(partition.header.date, now, formatterOptions));
+        } else {
+          outputLines.push(
+            formatItemHeadHeader(
+              partition.header.displayLabel,
+              undefined,
+              formatterOptions,
+            ),
+          );
+        }
+
+        // Format items
+        for (const item of partition.items) {
+          const dateStr = item.data.placement.head.kind === "date"
+            ? item.data.placement.head.date.toString()
+            : undefined;
+          outputLines.push(formatItemLine(item, formatterOptions, dateStr));
+        }
+
+        // Format stubs
+        for (const stub of partition.stubs) {
+          const stubSummary: SectionSummary = {
+            placement: createPlacement(
+              partition.header.kind === "date"
+                ? { kind: "date", date: partition.header.date }
+                : partition.header.parent.head,
+              [],
+            ),
+            itemCount: stub.itemCount,
+            sectionCount: stub.sectionCount,
+          };
+          outputLines.push(formatSectionStub(stubSummary, stub.relativePath, formatterOptions));
+        }
+
+        // Add empty line between partitions
+        outputLines.push("");
+      }
+
+      // Remove trailing empty line
+      while (outputLines.length > 0 && outputLines[outputLines.length - 1] === "") {
+        outputLines.pop();
+      }
+
+      const output = outputLines.join("\n");
+
+      // Output handling: pager/no-pager/print
+      if (isPrintMode || options.noPager) {
+        console.log(output);
+      } else {
+        await outputWithPager(output);
+      }
+    });
+}

--- a/src/presentation/cli/commands/snooze.ts
+++ b/src/presentation/cli/commands/snooze.ts
@@ -13,11 +13,33 @@ const formatItemLabel = (
 
 export function createSnoozeCommand() {
   return new Command()
-    .description("Snooze item until a future datetime")
-    .arguments("<locator:string> [until:string]")
+    .description("Snooze items until a future datetime")
+    .arguments("<ids...:string>")
     .option("-w, --workspace <workspace:string>", "Workspace to override")
-    .option("-c, --clear", "Clear snooze (unsnooze item)")
-    .action(async (options: Record<string, unknown>, itemLocator: string, until?: string) => {
+    .option("-c, --clear", "Clear snooze (unsnooze items)")
+    .action(async (options: Record<string, unknown>, ...args: string[]) => {
+      // Parse arguments: try to determine if last arg is "until" time or an item ref
+      if (args.length === 0) {
+        console.error("Error: At least one item id is required");
+        return;
+      }
+
+      const clearFlag = options.clear === true;
+      let itemRefs: string[];
+      let until: string | undefined;
+
+      // If clearFlag is set, all args are item refs
+      // Otherwise, try to parse: if we have multiple args, last might be "until"
+      if (clearFlag || args.length === 1) {
+        itemRefs = args;
+        until = undefined;
+      } else {
+        // Assume last arg might be "until" - we'll validate it later
+        // For now, treat last arg as potentially "until"
+        itemRefs = args.slice(0, -1);
+        until = args[args.length - 1];
+      }
+
       const workspaceOption = typeof options.workspace === "string" ? options.workspace : undefined;
       const depsResult = await loadCliDependencies(workspaceOption);
       if (depsResult.type === "error") {
@@ -51,37 +73,12 @@ export function createSnoozeCommand() {
         return;
       }
 
-      const clearFlag = options.clear === true;
-
-      // Resolve item expression to ItemId
-      const itemExprResult = parsePathExpression(itemLocator);
-      if (itemExprResult.type === "error") {
-        console.error(itemExprResult.error.message);
-        return;
-      }
-
       const pathResolver = createPathResolver({
         aliasRepository: deps.aliasRepository,
         itemRepository: deps.itemRepository,
         timezone: deps.timezone,
         today: now,
       });
-
-      const itemPlacementResult = await pathResolver.resolvePath(
-        cwdResult.value,
-        itemExprResult.value,
-      );
-      if (itemPlacementResult.type === "error") {
-        console.error(itemPlacementResult.error.message);
-        return;
-      }
-
-      if (itemPlacementResult.value.head.kind !== "item") {
-        console.error("Item expression must resolve to an item, not a date");
-        return;
-      }
-
-      const itemId = itemPlacementResult.value.head.id;
 
       // Resolve snoozeUntil expression to DateTime (if provided)
       let snoozeUntil = undefined;
@@ -91,60 +88,90 @@ export function createSnoozeCommand() {
           timezone: deps.timezone,
         });
         if (parseResult.type === "error") {
-          console.error(parseResult.error.message);
-          return;
+          // If parsing "until" fails, treat it as an item ref instead
+          itemRefs.push(until);
+          until = undefined;
+        } else {
+          snoozeUntil = parseResult.value;
         }
-        snoozeUntil = parseResult.value;
       }
 
-      const workflowResult = await SnoozeItemWorkflow.execute(
-        {
-          itemId,
-          snoozeUntil,
-          clear: clearFlag,
-          timezone: deps.timezone,
-          occurredAt: occurredAtResult.value,
-        },
-        {
-          itemRepository: deps.itemRepository,
-          rankService: deps.rankService,
-        },
-      );
+      // Process each item
+      for (const itemRef of itemRefs) {
+        // Resolve item expression to ItemId
+        const itemExprResult = parsePathExpression(itemRef);
+        if (itemExprResult.type === "error") {
+          console.error(`Error processing ${itemRef}: ${itemExprResult.error.message}`);
+          continue;
+        }
 
-      if (workflowResult.type === "error") {
-        console.error(workflowResult.error.message);
-        return;
-      }
-
-      const { item } = workflowResult.value;
-      const label = formatItemLabel(item);
-
-      if (item.data.snoozeUntil) {
-        // Format snoozeUntil in workspace timezone (YYYY-MM-DD HH:MM)
-        const date = item.data.snoozeUntil.toDate();
-        const dateFormatter = new Intl.DateTimeFormat("en-CA", {
-          timeZone: deps.timezone.toString(),
-          year: "numeric",
-          month: "2-digit",
-          day: "2-digit",
-        });
-        const timeFormatter = new Intl.DateTimeFormat("en-US", {
-          timeZone: deps.timezone.toString(),
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: false,
-        });
-        const datePart = dateFormatter.format(date); // YYYY-MM-DD
-        const timePart = timeFormatter.format(date); // HH:MM
-        const formattedTime = `${datePart} ${timePart}`;
-
-        console.log(
-          `💤 [${label}] "${item.data.title.toString()}" is snoozing until ${formattedTime}`,
+        const itemPlacementResult = await pathResolver.resolvePath(
+          cwdResult.value,
+          itemExprResult.value,
         );
-      } else {
-        console.log(
-          `[${label}] "${item.data.title.toString()}" is no longer snoozing`,
+        if (itemPlacementResult.type === "error") {
+          console.error(`Error processing ${itemRef}: ${itemPlacementResult.error.message}`);
+          continue;
+        }
+
+        if (itemPlacementResult.value.head.kind !== "item") {
+          console.error(
+            `Error processing ${itemRef}: expression must resolve to an item, not a date`,
+          );
+          continue;
+        }
+
+        const itemId = itemPlacementResult.value.head.id;
+
+        const workflowResult = await SnoozeItemWorkflow.execute(
+          {
+            itemId,
+            snoozeUntil,
+            clear: clearFlag,
+            timezone: deps.timezone,
+            occurredAt: occurredAtResult.value,
+          },
+          {
+            itemRepository: deps.itemRepository,
+            rankService: deps.rankService,
+          },
         );
+
+        if (workflowResult.type === "error") {
+          console.error(`Error processing ${itemRef}: ${workflowResult.error.message}`);
+          continue;
+        }
+
+        const { item } = workflowResult.value;
+        const label = formatItemLabel(item);
+
+        if (item.data.snoozeUntil) {
+          // Format snoozeUntil in workspace timezone (YYYY-MM-DD HH:MM)
+          const date = item.data.snoozeUntil.toDate();
+          const dateFormatter = new Intl.DateTimeFormat("en-CA", {
+            timeZone: deps.timezone.toString(),
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          });
+          const timeFormatter = new Intl.DateTimeFormat("en-US", {
+            timeZone: deps.timezone.toString(),
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          });
+          const datePart = dateFormatter.format(date); // YYYY-MM-DD
+          const timePart = timeFormatter.format(date); // HH:MM
+          const formattedTime = `${datePart} ${timePart}`;
+
+          console.log(
+            `💤 [${label}] "${item.data.title.toString()}" is snoozing until ${formattedTime}`,
+          );
+        } else {
+          console.log(
+            `[${label}] "${item.data.title.toString()}" is no longer snoozing`,
+          );
+        }
       }
     });
 }

--- a/src/presentation/cli/commands/where.ts
+++ b/src/presentation/cli/commands/where.ts
@@ -13,9 +13,9 @@ const formatItemLabel = (
 export function createWhereCommand() {
   return new Command()
     .description("Show logical and physical paths for an item")
-    .arguments("<locator:string>")
+    .arguments("<id:string>")
     .option("-w, --workspace <workspace:string>", "Workspace to override")
-    .action(async (options: Record<string, unknown>, locatorArg: string) => {
+    .action(async (options: Record<string, unknown>, itemRef: string) => {
       const debug = isDebugMode();
       const workspaceOption = typeof options.workspace === "string" ? options.workspace : undefined;
       const depsResult = await loadCliDependencies(workspaceOption);
@@ -32,7 +32,7 @@ export function createWhereCommand() {
 
       // Try to resolve as UUID first, then as alias
       let item;
-      const uuidResult = parseItemId(locatorArg);
+      const uuidResult = parseItemId(itemRef);
 
       if (uuidResult.type === "ok") {
         // It's a valid UUID
@@ -44,7 +44,7 @@ export function createWhereCommand() {
         item = loadResult.value;
       } else {
         // Try as alias
-        const aliasResult = parseAliasSlug(locatorArg);
+        const aliasResult = parseAliasSlug(itemRef);
         if (aliasResult.type === "ok") {
           const aliasLoadResult = await deps.aliasRepository.load(aliasResult.value);
           if (aliasLoadResult.type === "error") {
@@ -64,7 +64,7 @@ export function createWhereCommand() {
       }
 
       if (!item) {
-        console.error(`Item not found: ${locatorArg}`);
+        console.error(`Item not found: ${itemRef}`);
         return;
       }
 


### PR DESCRIPTION
## Summary

Enhance CLI usability by adding command aliases and enabling batch operations on multiple items. Users can now work more efficiently with shorter commands and process multiple items at once.

## Changes

### Command Aliases
- `close` → `cl` alias for quicker access
- `reopen` → `op` alias for quicker access  
- `ls` → renamed to `list` (ls remains as alias)
- `mv` → renamed to `move` (mv remains as alias)

### Batch Operations
- **move command**: Now accepts multiple item IDs to move them together
  - Example: `mm move id1 id2 id3 today`
  - Items are placed in the specified order
- **snooze command**: Now accepts multiple item IDs to snooze at once
  - Example: `mm snooze id1 id2 tomorrow`

### Consistency Improvements
- Updated command argument names from `<locator>` to `<id>` / `<ids...>` for clarity
- Internal variable naming improved to use `itemRef` / `itemRefs`

## Test Plan

- [x] All unit tests pass (255 tests)
- [x] All E2E tests pass (163 steps)
- [x] `deno lint` - clean
- [x] `deno fmt` - clean
- [x] `deno check` - passes
- [x] Backward compatibility maintained through aliases

## Affected Modules

- `src/main.ts` - Command registration and aliases
- `src/presentation/cli/commands/list.ts` - Renamed from ls.ts
- `src/presentation/cli/commands/move.ts` - Renamed from mv.ts, added multi-item support
- `src/presentation/cli/commands/snooze.ts` - Added multi-item support
- `src/presentation/cli/commands/where.ts` - Argument name update
- `src/presentation/cli/commands/edit.ts` - Argument name update

🤖 Generated with [Claude Code](https://claude.com/claude-code)