### PR TITLE
feat(ls): use weekday names and tilde notation for relative dates

### DIFF
--- a/docs/stories/20251223T134542_ls-relative-date-enhancement.story.md
+++ b/docs/stories/20251223T134542_ls-relative-date-enhancement.story.md
@@ -1,0 +1,103 @@
+## Story Log
+
+### Goal
+Improve `mm ls` relative date display to use weekday names and consistent notation.
+
+### Why
+The current relative date display has two issues:
+1. Within a week, people naturally think in weekdays ("next Monday", "last Friday") rather than day counts ("+3d", "-2d")
+2. The display uses `-Xd` for past dates, but the command input uses `~Xd`, causing confusion
+
+### User Story
+**As a mm user, I want `mm ls` to display relative dates using weekday names for the past/next week and use `~Xd` notation for older dates, so that the output is more intuitive and consistent with command input format.**
+
+### Acceptance Criteria
+
+#### 1. Weekday Display for Past Week
+- [x] **Given** a date that is 2-6 days in the past, **When** running `mm ls`, **Then** it displays as `last-{weekday}` (e.g., `last-monday`, `last-friday`)
+- [x] **Given** a date that is exactly 7 days in the past (same weekday as today), **When** running `mm ls`, **Then** it displays as `last-{weekday}`
+
+#### 2. Weekday Display for Next Week
+- [x] **Given** a date that is 2-6 days in the future, **When** running `mm ls`, **Then** it displays as `next-{weekday}` (e.g., `next-monday`, `next-friday`)
+- [x] **Given** a date that is exactly 7 days in the future (same weekday as today), **When** running `mm ls`, **Then** it displays as `next-{weekday}`
+
+#### 3. Today/Tomorrow/Yesterday Unchanged
+- [x] **Given** today's date, **When** running `mm ls`, **Then** it displays as `today` (unchanged)
+- [x] **Given** tomorrow's date, **When** running `mm ls`, **Then** it displays as `tomorrow` (unchanged)
+- [x] **Given** yesterday's date, **When** running `mm ls`, **Then** it displays as `yesterday` (unchanged)
+
+#### 4. Tilde Notation for Dates Beyond a Week
+- [x] **Given** a date that is 8+ days in the past, **When** running `mm ls`, **Then** it displays as `~Xd` (e.g., `~8d`, `~14d`)
+- [x] **Given** a date that is 8+ days in the future, **When** running `mm ls`, **Then** it displays as `+Xd` (e.g., `+8d`, `+14d`)
+
+#### 5. Print Mode Compatibility
+- [x] **Given** the `--print` flag is used, **When** running `mm ls --print`, **Then** the relative date labels are displayed without ANSI formatting
+
+### Out of Scope
+- Changing the parsing/input format (already uses `~Xd`, weekday syntax)
+- Localization of weekday names (use English lowercase: monday, tuesday, etc.)
+- Changing the date format `[YYYY-MM-DD]` itself
+
+---
+
+### Completed Work Summary
+
+**Implementation completed:**
+
+1. Modified `computeRelativeLabel` function in `src/presentation/cli/formatters/list_formatter.ts`:
+   - Added `WEEKDAY_NAMES` constant for day-of-week to weekday name mapping
+   - Changed +2 to +7 days to display as `next-{weekday}` (e.g., `next-wednesday`)
+   - Changed -2 to -7 days to display as `last-{weekday}` (e.g., `last-saturday`)
+   - Changed dates beyond -7 days to display as `~Xd` (tilde notation, consistent with input)
+   - Changed dates beyond +7 days to display as `+Xd`
+
+2. Updated tests in `src/presentation/cli/formatters/list_formatter_test.ts`:
+   - Modified existing `+2d` test to expect `next-wednesday`
+   - Added test for `-2d` → `last-saturday`
+   - Added test for `+7d` → `next-monday`
+   - Added test for `-7d` → `last-monday`
+   - Changed "far future" test to expect `+19d` instead of no label
+   - Changed "far past" test to expect `~40d` instead of no label
+   - Added boundary tests for `+8d` and `~8d`
+
+3. Updated doc comments for `formatDateHeader` function
+
+**Key design decisions:**
+- Used UTC weekday calculation (`getUTCDay()`) consistent with existing date handling
+- Reused lowercase weekday format consistent with `date_resolver.ts` (next-monday, last-friday)
+- All existing tests for today/tomorrow/yesterday remain unchanged
+
+**Test coverage:**
+- Unit tests: 490 passed (all formatDateHeader tests pass)
+- E2E tests: 27 passed, 1 failed (unrelated shell completion environment issue)
+
+### Acceptance Checks
+
+**Status: Accepted**
+
+Developer verification completed:
+- Verified weekday labels display correctly for ±2 to ±7 days
+- Verified tilde notation (~Xd) for past dates beyond a week
+- Verified plus notation (+Xd) for future dates beyond a week
+- Verified today/tomorrow/yesterday unchanged
+- Verified print mode works correctly (no ANSI codes in tests)
+- All unit tests pass
+- E2E tests pass (except unrelated shell completion test)
+
+**Acceptance testing results (2025-12-23):**
+- AC.1 PASSED: `last-sunday`, `last-saturday`, `last-tuesday` displayed correctly for -2d to -7d
+- AC.2 PASSED: `next-thursday`, `next-friday`, `next-tuesday` displayed correctly for +2d to +7d
+- AC.3 PASSED: `today`, `tomorrow`, `yesterday` labels unchanged
+- AC.4 PASSED: `~8d` for -8d, `+8d` for +8d displayed correctly
+- AC.5 PASSED: Print mode output contains no ANSI escape codes
+
+All acceptance criteria verified in temporary workspace `/tmp/tmp.dBZbIohEgy`.
+
+### Follow-ups / Open Risks
+
+#### Addressed
+- Weekday calculation uses UTC consistently with existing codebase
+- Weekday format matches existing `date_resolver.ts` conventions
+
+#### Remaining
+- (none identified)

--- a/src/presentation/cli/formatters/list_formatter_test.ts
+++ b/src/presentation/cli/formatters/list_formatter_test.ts
@@ -287,7 +287,8 @@ Deno.test("formatDateHeader - yesterday shows relative label", () => {
   assertEquals(result, "[2025-02-09] yesterday");
 });
 
-Deno.test("formatDateHeader - +2d shows relative label", () => {
+// 2025-02-10 is Monday, so +2d (2025-02-12) is Wednesday
+Deno.test("formatDateHeader - +2d shows next-wednesday (weekday label)", () => {
   const day = makeCalendarDay("2025-02-12");
   const referenceDate = new Date("2025-02-10T12:00:00Z");
   const options: ListFormatterOptions = {
@@ -295,10 +296,47 @@ Deno.test("formatDateHeader - +2d shows relative label", () => {
     timezone: makeTimezone(),
   };
   const result = formatDateHeader(day, referenceDate, options);
-  assertEquals(result, "[2025-02-12] +2d");
+  assertEquals(result, "[2025-02-12] next-wednesday");
 });
 
-Deno.test("formatDateHeader - far future shows no relative label", () => {
+// 2025-02-10 is Monday, so -2d (2025-02-08) is Saturday
+Deno.test("formatDateHeader - -2d shows last-saturday (weekday label)", () => {
+  const day = makeCalendarDay("2025-02-08");
+  const referenceDate = new Date("2025-02-10T12:00:00Z");
+  const options: ListFormatterOptions = {
+    printMode: true,
+    timezone: makeTimezone(),
+  };
+  const result = formatDateHeader(day, referenceDate, options);
+  assertEquals(result, "[2025-02-08] last-saturday");
+});
+
+// 2025-02-10 is Monday, so +7d (2025-02-17) is Monday
+Deno.test("formatDateHeader - +7d shows next-monday (weekday label)", () => {
+  const day = makeCalendarDay("2025-02-17");
+  const referenceDate = new Date("2025-02-10T12:00:00Z");
+  const options: ListFormatterOptions = {
+    printMode: true,
+    timezone: makeTimezone(),
+  };
+  const result = formatDateHeader(day, referenceDate, options);
+  assertEquals(result, "[2025-02-17] next-monday");
+});
+
+// 2025-02-10 is Monday, so -7d (2025-02-03) is Monday
+Deno.test("formatDateHeader - -7d shows last-monday (weekday label)", () => {
+  const day = makeCalendarDay("2025-02-03");
+  const referenceDate = new Date("2025-02-10T12:00:00Z");
+  const options: ListFormatterOptions = {
+    printMode: true,
+    timezone: makeTimezone(),
+  };
+  const result = formatDateHeader(day, referenceDate, options);
+  assertEquals(result, "[2025-02-03] last-monday");
+});
+
+// 2025-03-01 is 19 days after 2025-02-10
+Deno.test("formatDateHeader - far future shows +Xd label", () => {
   const day = makeCalendarDay("2025-03-01");
   const referenceDate = new Date("2025-02-10T12:00:00Z");
   const options: ListFormatterOptions = {
@@ -306,10 +344,11 @@ Deno.test("formatDateHeader - far future shows no relative label", () => {
     timezone: makeTimezone(),
   };
   const result = formatDateHeader(day, referenceDate, options);
-  assertEquals(result, "[2025-03-01]");
+  assertEquals(result, "[2025-03-01] +19d");
 });
 
-Deno.test("formatDateHeader - far past shows no relative label", () => {
+// 2025-01-01 is 40 days before 2025-02-10
+Deno.test("formatDateHeader - far past shows ~Xd label", () => {
   const day = makeCalendarDay("2025-01-01");
   const referenceDate = new Date("2025-02-10T12:00:00Z");
   const options: ListFormatterOptions = {
@@ -317,7 +356,31 @@ Deno.test("formatDateHeader - far past shows no relative label", () => {
     timezone: makeTimezone(),
   };
   const result = formatDateHeader(day, referenceDate, options);
-  assertEquals(result, "[2025-01-01]");
+  assertEquals(result, "[2025-01-01] ~40d");
+});
+
+// 2025-02-18 is 8 days after 2025-02-10 (just beyond weekday range)
+Deno.test("formatDateHeader - +8d shows +8d label (beyond weekday range)", () => {
+  const day = makeCalendarDay("2025-02-18");
+  const referenceDate = new Date("2025-02-10T12:00:00Z");
+  const options: ListFormatterOptions = {
+    printMode: true,
+    timezone: makeTimezone(),
+  };
+  const result = formatDateHeader(day, referenceDate, options);
+  assertEquals(result, "[2025-02-18] +8d");
+});
+
+// 2025-02-02 is 8 days before 2025-02-10 (just beyond weekday range)
+Deno.test("formatDateHeader - -8d shows ~8d label (beyond weekday range)", () => {
+  const day = makeCalendarDay("2025-02-02");
+  const referenceDate = new Date("2025-02-10T12:00:00Z");
+  const options: ListFormatterOptions = {
+    printMode: true,
+    timezone: makeTimezone(),
+  };
+  const result = formatDateHeader(day, referenceDate, options);
+  assertEquals(result, "[2025-02-02] ~8d");
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Display weekday names (e.g., `next-monday`, `last-friday`) for dates within ±2-7 days instead of day counts
- Use tilde notation (`~Xd`) for past dates beyond a week, consistent with command input format
- Keep `today`, `tomorrow`, `yesterday` labels unchanged

## Story
See `docs/stories/20251223T134542_ls-relative-date-enhancement.story.md`

## Test Plan
- [x] Unit tests: 44 tests pass for `list_formatter.ts`
- [x] Manual verification with temporary workspace
- [x] Acceptance testing for all 5 criteria passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)