### PR TITLE
perf: optimize timezone validation for faster ls command startup

### DIFF
--- a/src/domain/primitives/timezone_identifier.ts
+++ b/src/domain/primitives/timezone_identifier.ts
@@ -5,6 +5,7 @@ import {
   ValidationError,
 } from "../../shared/errors.ts";
 import { createStringPrimitiveFactory, StringPrimitive } from "./string_primitive.ts";
+import { profileSync } from "../../shared/profiler.ts";
 
 const TIMEZONE_IDENTIFIER_KIND = "TimezoneIdentifier" as const;
 const timezoneIdentifierFactory = createStringPrimitiveFactory({
@@ -27,11 +28,66 @@ export type TimezoneIdentifierValidationError = ValidationError<typeof TIMEZONE_
 export const isTimezoneIdentifier = (value: unknown): value is TimezoneIdentifier =>
   timezoneIdentifierFactory.is(value);
 
+// Common IANA timezones to avoid Intl.DateTimeFormat initialization overhead
+const KNOWN_TIMEZONES = new Set([
+  "UTC",
+  "GMT",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "America/Toronto",
+  "America/Vancouver",
+  "America/Sao_Paulo",
+  "America/Mexico_City",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Europe/Amsterdam",
+  "Europe/Rome",
+  "Europe/Madrid",
+  "Europe/Zurich",
+  "Asia/Tokyo",
+  "Asia/Shanghai",
+  "Asia/Hong_Kong",
+  "Asia/Singapore",
+  "Asia/Seoul",
+  "Asia/Taipei",
+  "Asia/Bangkok",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Jakarta",
+  "Australia/Sydney",
+  "Australia/Melbourne",
+  "Australia/Brisbane",
+  "Australia/Perth",
+  "Pacific/Auckland",
+  "Pacific/Honolulu",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+]);
+
+// Cache for validated timezones to avoid repeated Intl.DateTimeFormat instantiation
+const validatedTimezones = new Map<string, boolean>();
+
 const isValidTimezone = (value: string): boolean => {
+  // Fast path for known timezones
+  if (KNOWN_TIMEZONES.has(value)) {
+    return true;
+  }
+
+  const cached = validatedTimezones.get(value);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   try {
     new Intl.DateTimeFormat("en-US", { timeZone: value });
+    validatedTimezones.set(value, true);
     return true;
   } catch {
+    validatedTimezones.set(value, false);
     return false;
   }
 };
@@ -39,8 +95,9 @@ const isValidTimezone = (value: string): boolean => {
 export const parseTimezoneIdentifier = (
   input: unknown,
 ): Result<TimezoneIdentifier, TimezoneIdentifierValidationError> => {
-  if (isTimezoneIdentifier(input)) {
-    return Result.ok(input);
+  const isAlready = profileSync("tz:isTimezoneIdentifier", () => isTimezoneIdentifier(input));
+  if (isAlready) {
+    return Result.ok(input as TimezoneIdentifier);
   }
 
   if (typeof input !== "string") {
@@ -66,7 +123,8 @@ export const parseTimezoneIdentifier = (
     );
   }
 
-  if (!isValidTimezone(candidate)) {
+  const valid = profileSync("tz:isValidTimezone", () => isValidTimezone(candidate));
+  if (!valid) {
     return Result.error(
       createValidationError(TIMEZONE_IDENTIFIER_KIND, [
         createValidationIssue("timezone must be a valid IANA identifier", {
@@ -77,7 +135,7 @@ export const parseTimezoneIdentifier = (
     );
   }
 
-  return Result.ok(instantiate(candidate));
+  return Result.ok(profileSync("tz:instantiate", () => instantiate(candidate)));
 };
 
 export const timezoneIdentifierFromString = (


### PR DESCRIPTION
## Summary

- Optimize timezone validation in `timezone_identifier.ts` to reduce cold start time
- Add KNOWN_TIMEZONES set with ~40 common IANA timezones to bypass slow `Intl.DateTimeFormat` initialization
- Add cache for validated timezones to avoid repeated validation

## Performance Results

**Root cause:** `new Intl.DateTimeFormat("en-US", { timeZone: value })` takes ~35ms on cold start to initialize locale data.

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| `tz:isValidTimezone` | 35ms (47%) | 0.05ms (0.1%) | **700x faster** |
| `loadCliDependencies` | 45ms (60%) | 12ms (19%) | **~4x faster** |
| **Total ls command (compiled)** | ~75ms | **51-53ms** | **~1.4x faster** |

**Note:** CI benchmark currently measures `deno run` overhead. See #77 for benchmark workflow fix.

## Changes

### `src/domain/primitives/timezone_identifier.ts`
- Add `KNOWN_TIMEZONES` set with common IANA timezone identifiers (UTC, GMT, America/*, Europe/*, Asia/*, etc.)
- Add `validatedTimezones` cache Map for unknown timezones
- Fast path: check `KNOWN_TIMEZONES.has(value)` before falling back to `Intl.DateTimeFormat`

### Profiling instrumentation
- `src/presentation/cli/dependencies.ts`
- `src/infrastructure/fileSystem/workspace_repository.ts`

## Test plan

- [x] Verify profiling shows improved performance: `MM_PROFILE=1 ./mm ls`
- [x] Verify multiple runs are consistent
- [x] Run E2E tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)