### PR TITLE
refactor(sync): remove lazy-sync mode completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,12 +428,11 @@ Supported keys: `timezone`, `sync.enabled`, `sync.mode`, `sync.git.remote`, `syn
 
 ### Git Synchronization
 
-mm supports Git-based synchronization to backup and sync workspaces across devices. Three sync modes
+mm supports Git-based synchronization to backup and sync workspaces across devices. Two sync modes
 are available:
 
 - **auto-commit**: Automatically commits changes after each operation (manual push required)
-- **auto-sync**: Automatically commits and pushes changes after each operation
-- **lazy-sync**: Automatically commits changes immediately, syncs periodically based on thresholds
+- **auto-sync**: Automatically commits and pushes changes (configurable thresholds for batched sync)
 
 #### `sync init <remote-url>`
 
@@ -498,15 +497,15 @@ automatically committed and pushed after each operation.
 **Sync Mode Configuration**: The sync mode defaults to `auto-commit`. To change it:
 
 ```sh
-mm config set sync.mode auto-sync      # Sync after every operation
-mm config set sync.mode lazy-sync      # Sync periodically based on thresholds
+mm config set sync.mode auto-sync      # Sync after every operation (default: immediate)
 ```
 
-**Lazy-sync Configuration**: In lazy-sync mode, sync is triggered when either threshold is reached:
+**Auto-sync Threshold Configuration**: By default, auto-sync pushes immediately after each commit.
+You can configure thresholds for batched sync:
 
 ```sh
-mm config set sync.lazy.commits 10     # Sync after 10 commits (default: 10)
-mm config set sync.lazy.minutes 10     # Sync after 10 minutes (default: 10)
+mm config set sync.lazy.commits 10     # Sync after 10 commits (default: 1)
+mm config set sync.lazy.minutes 10     # Sync after 10 minutes (default: 0, disabled)
 ```
 
 ### Maintenance

--- a/src/domain/models/workspace.ts
+++ b/src/domain/models/workspace.ts
@@ -20,11 +20,6 @@ export type LazySyncSettings = Readonly<{
   minutes: number;
 }>;
 
-export const DEFAULT_LAZY_SYNC_SETTINGS: LazySyncSettings = {
-  commits: 10,
-  minutes: 10,
-};
-
 export const DEFAULT_AUTO_SYNC_SETTINGS: LazySyncSettings = {
   commits: 1,
   minutes: 0,
@@ -160,8 +155,7 @@ export const parseWorkspaceSettings = (
   let syncSettings = DEFAULT_SYNC_SETTINGS;
   if (snapshot.sync) {
     let mode: VersionControlSyncMode;
-    if (snapshot.sync.mode === "auto-sync" || snapshot.sync.mode === "lazy-sync") {
-      // lazy-sync is now unified into auto-sync (backward compatibility)
+    if (snapshot.sync.mode === "auto-sync") {
       mode = "auto-sync";
     } else {
       mode = "auto-commit";
@@ -182,10 +176,10 @@ export const parseWorkspaceSettings = (
       lazySyncSettings = {
         commits: typeof snapshot.sync.lazy.commits === "number"
           ? snapshot.sync.lazy.commits
-          : DEFAULT_LAZY_SYNC_SETTINGS.commits,
+          : DEFAULT_AUTO_SYNC_SETTINGS.commits,
         minutes: typeof snapshot.sync.lazy.minutes === "number"
           ? snapshot.sync.lazy.minutes
-          : DEFAULT_LAZY_SYNC_SETTINGS.minutes,
+          : DEFAULT_AUTO_SYNC_SETTINGS.minutes,
       };
     }
 

--- a/src/infrastructure/git/sync_service_test.ts
+++ b/src/infrastructure/git/sync_service_test.ts
@@ -100,10 +100,6 @@ Deno.test("SyncService.pull", async (t) => {
     assertEquals(pullBranch, "main");
   });
 
-  // Note: lazy-sync mode is now unified into auto-sync at the parser level (workspace.ts).
-  // The SyncService only receives "auto-sync" mode; lazy-sync thresholds are handled by
-  // auto_commit_helper.ts using sync.lazy config settings.
-
   await t.step("skips pull when no remote configured", async () => {
     let pullCalled = false;
     const vcs = createMockVersionControlService({


### PR DESCRIPTION
## Summary

- Remove all lazy-sync related code (no existing users, no backward compatibility needed)
- Unify to single `DEFAULT_AUTO_SYNC_SETTINGS` (commits=1, minutes=0)
- Simplify sync.mode validation to only accept `auto-commit` | `auto-sync`

## Changes

- `workspace.ts`: Remove lazy-sync from parser, remove `DEFAULT_LAZY_SYNC_SETTINGS`
- `config.ts`: Simplify sync.mode validation, use single default
- `sync_service_test.ts`: Remove lazy-sync comment
- `scenario_26_pre_pull_test.ts`: Remove lazy-sync test case
- `README.md`: Update documentation

## Context

Follow-up to PR #83 (unify lazy-sync and auto-sync). Codex review pointed out backward compatibility code was unnecessary since there are no existing users. This PR removes all lazy-sync vestiges.

## Test Plan

- [x] All unit tests pass (541 tests)
- [x] All E2E tests pass (config, pre-pull, auto-sync scenarios)
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)