### PR TITLE
chore: add Claude Code Stop hook for code quality checks

### DIFF
--- a/.claude/hooks/check-code.sh
+++ b/.claude/hooks/check-code.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Stop hook: Run format check, lint, and type check
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+errors=""
+
+# Format check
+if ! deno fmt --check 2>&1; then
+  errors+="Format issues found. Run 'deno fmt' to fix.\n"
+fi
+
+# Lint
+lint_output=$(deno lint 2>&1)
+if [ $? -ne 0 ]; then
+  errors+="Lint issues found:\n$lint_output\n"
+fi
+
+# Type check
+check_output=$(deno check src/main.ts 2>&1)
+if [ $? -ne 0 ]; then
+  errors+="Type check failed:\n$check_output\n"
+fi
+
+if [ -n "$errors" ]; then
+  echo -e "$errors" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,18 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-code.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Add Stop hook that runs `deno fmt --check`, `deno lint`, and `deno check` when Claude stops responding
- Errors are fed back to Claude to prompt automatic fixes
- Hook script located at `.claude/hooks/check-code.sh`

## Test plan
- [x] Restart Claude Code session to load the new hooks
- [x] Make a code change that introduces a lint error
- [x] Verify Claude is prompted to fix the issue when it stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)